### PR TITLE
deb: fix dpkg-buildpackage command

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ definition to build and push packages in two steps:
 ```shell
 # build all packages for buildx v0.9.1 and output to ./bin folder
 $ cd pkg/buildx/ 
-$ BUILDX_VERSION=v0.9.1 make pkg
+$ BUILDX_VERSION=v0.9.1 make all
 # build and push image to dockereng/packaging:buildx-v0.9.1 using bake.
 # "release" target will use the "bin" folder as named context to create the
 # image with artifacts previously built with make.

--- a/pkg/credential-helpers/Dockerfile
+++ b/pkg/credential-helpers/Dockerfile
@@ -125,7 +125,7 @@ EOF
   xx-go --wrap
   set -x
   chmod -x debian/compat debian/control debian/docs
-  dpkg-buildpackage -us -uc -a$(xx-info debian-arch) -Pcross,nocheck
+  dpkg-buildpackage -us -uc
   pkgoutput="/out/${PKG_DISTRO}/${PKG_SUITE}/$(xx-info arch)"
   if [ -n "$(xx-info variant)" ]; then
     pkgoutput="${pkgoutput}/$(xx-info variant)"

--- a/pkg/docker-cli/Dockerfile
+++ b/pkg/docker-cli/Dockerfile
@@ -126,7 +126,7 @@ EOF
   xx-go --wrap
   set -x
   chmod -x debian/compat debian/control debian/docs debian/*.bash-completion debian/*.manpages
-  dpkg-buildpackage -us -uc -a$(xx-info debian-arch) -Pcross,nocheck
+  dpkg-buildpackage -us -uc
   pkgoutput="/out/${PKG_DISTRO}/${PKG_SUITE}/$(xx-info arch)"
   if [ -n "$(xx-info variant)" ]; then
     pkgoutput="${pkgoutput}/$(xx-info variant)"

--- a/pkg/docker-cli/Makefile
+++ b/pkg/docker-cli/Makefile
@@ -22,6 +22,9 @@ $(info $$BASEDIR = $(BASEDIR))
 $(info $$DOCKER_CLI_REPO = $(DOCKER_CLI_REPO))
 $(info $$DOCKER_CLI_VERSION = $(DOCKER_CLI_VERSION))
 
+export PKG_DEB_REVISION = 3
+export PKG_RPM_RELEASE = 3
+
 .PHONY: all
 all: pkg
 


### PR DESCRIPTION
cross and nocheck opts added by mistake while
testing cross compilation for deb packaging

also set deb/rpm revision to 3 for docker-cli

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>