### PR TITLE
pkg(docker-engine): remove workaround for broken ubuntu 18.04 repo

### DIFF
--- a/pkg/docker-engine/internal/pkg-deb-init.sh
+++ b/pkg/docker-engine/internal/pkg-deb-init.sh
@@ -37,10 +37,6 @@ fi
 set -x
 
 case "$PKG_RELEASE" in
-  ubuntu1804)
-    # FIXME: https://github.com/docker/docker-ce-packaging/issues/758
-    apt-get install --allow-downgrades -y libudev1=237-3ubuntu10.53 libsystemd0=237-3ubuntu10.53
-    ;;
   ubuntu2004|ubuntu2204)
     if [ "$(dpkg-divert --truename /usr/bin/man)" = "/usr/bin/man.REAL" ]; then
       rm -f /usr/bin/man


### PR DESCRIPTION
follow-up https://github.com/docker/docker-ce-packaging/issues/758#issuecomment-1239601049

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>