### PR TITLE
ci(release): split pkgs in dyn matrix and use remote builders

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,9 +121,22 @@ jobs:
           name: ${{ inputs.package }}
           path: ./pkg/${{ inputs.package }}/bin
       -
-        name: List artifacts
+        name: List artifacts and set summary
         run: |
-          tree -nh ./pkg/${{ inputs.package }}/bin
+          tree -nh ./pkg/${{ inputs.package }}/bin | tee /tmp/pkgs.txt
+          cat > /tmp/summary.txt <<EOF
+          $(make --no-print-directory -C pkg/${{ inputs.package }} summary)
+          * packages: $(find ./pkg/${{ inputs.package }}/bin -type f | wc -l) files / $(du -sh ./pkg/${{ inputs.package }}/bin | awk '{print $1}')
+          EOF
+      -
+        name: Set packages list and summary outputs
+        uses: actions/github-script@v6
+        id: release-summary
+        with:
+          script: |
+            const fs = require('fs');
+            core.setOutput('pkgs', fs.readFileSync('/tmp/pkgs.txt', {encoding: 'utf8'}));
+            core.setOutput('summary', fs.readFileSync('/tmp/summary.txt', {encoding: 'utf8'}));
       -
         name: Docker meta
         id: meta
@@ -173,11 +186,23 @@ jobs:
           body: |
             Image available at [https://hub.docker.com/r/${{ env.REPO_SLUG }}](https://hub.docker.com/r/${{ env.REPO_SLUG }}).
             
+            ## Summary
+            ${{ steps.release-summary.outputs.summary }}
+            
             ## Usage
             Extract with [Undock](https://github.com/crazy-max/undock):
             ```console
             $ undock --wrap --rm-dist --all ${{ env.REPO_SLUG }}:${{ steps.meta.outputs.version }} ./${{ inputs.package }}/${{ env.VERSION }}
             ```
+            
+            ## Packages
+            <details>
+              <summary>Show list</summary>
+
+            ```text
+            ${{ steps.release-summary.outputs.pkgs }}
+            ```
+            </details>
             
             ## Build result metadata
             <details>

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,37 @@ on:
 env:
   # FIXME: temporary for testing, use dockereng/packaging
   REPO_SLUG: crazymax/docker-packaging
+  # FIXME: use dockereng/packaging-cache
+  BUILD_CACHE_REGISTRY_SLUG: crazymax/docker-packaging-cache
 
 jobs:
+  prepare:
+    runs-on: ubuntu-20.04
+    outputs:
+      matrix: ${{ steps.pkgs.outputs.matrix }}
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Create matrix
+        id: pkgs
+        run: |
+          pkgs=$(make gha-release-matrix)
+          echo "::set-output name=matrix::$pkgs"
+      -
+        name: Show matrix
+        run: |
+          echo ${{ steps.pkgs.outputs.matrix }}
+
   build:
     runs-on: ubuntu-20.04
+    needs:
+      - prepare
+    strategy:
+      fail-fast: true
+      matrix:
+        pkg: ${{ fromJson(needs.prepare.outputs.matrix) }}
     steps:
       -
         name: Checkout
@@ -28,11 +55,55 @@ jobs:
         uses: docker/setup-qemu-action@v2
       -
         name: Set up Docker Buildx
+        id: buildx
         uses: docker/setup-buildx-action@v2
       -
-        # necessary to use gha cache export
-        name: Expose GitHub Runtime
-        uses: crazy-max/ghaction-github-runtime@v2
+        name: Set up remote builders
+        if: matrix.pkg != 'static' # do not use remote builders for static builds (cross)
+        # FIXME: use docker/setup-buildx-action@v2 when https://github.com/docker/setup-buildx-action/pull/165 merged
+        uses: crazy-max/docker-setup-buildx-action@append
+        with:
+          driver: remote
+          endpoint: docker-container://buildx_buildkit_${{ steps.buildx.outputs.name }}0
+          append: |
+            - name: aws_graviton2
+              endpoint: tcp://${{ secrets.AWS_ARM64_HOST }}:1234
+              platforms: darwin/arm64,linux/arm64,linux/arm/v5,linux/arm/v6,linux/arm/v7,windows/arm64
+            - name: linuxone_s390x
+              endpoint: tcp://${{ secrets.LINUXONE_S390X_HOST }}:1234
+              platforms: linux/s390x
+        env:
+          BUILDER_NODE_1_AUTH_TLS_CACERT: ${{ secrets.AWS_ARM64_CACERT }}
+          BUILDER_NODE_1_AUTH_TLS_CERT: ${{ secrets.AWS_ARM64_CERT }}
+          BUILDER_NODE_1_AUTH_TLS_KEY: ${{ secrets.AWS_ARM64_KEY }}
+          BUILDER_NODE_2_AUTH_TLS_CACERT: ${{ secrets.LINUXONE_S390X_CACERT }}
+          BUILDER_NODE_2_AUTH_TLS_CERT: ${{ secrets.LINUXONE_S390X_CERT }}
+          BUILDER_NODE_2_AUTH_TLS_KEY: ${{ secrets.LINUXONE_S390X_KEY }}
+      -
+        name: Build
+        run: |
+          make -C pkg/${{ inputs.package }} build-${{ matrix.pkg }}
+      -
+        name: List artifacts
+        run: |
+          tree -nh ./pkg/${{ inputs.package }}/bin
+      -
+        name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ inputs.package }}
+          path: ./pkg/${{ inputs.package }}/bin/*
+          if-no-files-found: error
+          retention-days: 1
+
+  release:
+    runs-on: ubuntu-20.04
+    needs:
+      - build
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
       -
         name: Prepare
         run: |
@@ -42,12 +113,13 @@ jobs:
           echo "Release: ${{ inputs.release }}"
           echo "Git tag prefix: $git_tag"
           echo "GIT_TAG=$git_tag" >> $GITHUB_ENV
+          echo "VERSION=$version" >> $GITHUB_ENV
       -
-        name: Build pkgs
-        run: |
-          make -C pkg/${{ inputs.package }}
-        env:
-          BUILD_CACHE_SCOPE: release-${{ inputs.package }}
+        name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ inputs.package }}
+          path: ./pkg/${{ inputs.package }}/bin
       -
         name: List artifacts
         run: |
@@ -76,7 +148,11 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
         name: Build image
+        id: build
         uses: docker/bake-action@v2
         with:
           workdir: ./pkg/${{ inputs.package }}
@@ -95,9 +171,21 @@ jobs:
           tag_name: ${{ env.GIT_TAG }}-${{ github.run_number }}
           target_commitish: ${{ github.sha }}
           body: |
-            Image available at [https://hub.docker.com/r/${{ env.REPO_SLUG }}](https://hub.docker.com/r/${{ env.REPO_SLUG }})
-            ```json
-            ${{ steps.meta.outputs.json }}
+            Image available at [https://hub.docker.com/r/${{ env.REPO_SLUG }}](https://hub.docker.com/r/${{ env.REPO_SLUG }}).
+            
+            ## Usage
+            Extract with [Undock](https://github.com/crazy-max/undock):
+            ```console
+            $ undock --wrap --rm-dist --all ${{ env.REPO_SLUG }}:${{ steps.meta.outputs.version }} ./${{ inputs.package }}/${{ env.VERSION }}
             ```
+            
+            ## Build result metadata
+            <details>
+              <summary><code>metadata.json</code></summary>
+
+            ```json
+            ${{ steps.build.outputs.metadata }}
+            ```
+            </details>
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -35,3 +35,9 @@ rpm-%:
 .PHONY: static-%
 static-%:
 	$(MAKE) -C pkg/$* pkg-static
+
+include common/packages.mk
+
+.PHONY: gha-release-matrix
+gha-release-matrix:
+	@echo "$(PKG_DEB_RELEASES) $(PKG_RPM_RELEASES) static" | jq -cR 'split(" ")'

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ $ docker buildx create --driver docker-container --name mybuilder --use --bootst
 >
 > Some packages don't have cross-compilation support and therefore QEMU will
 > be used. As it can be slow, it is recommended to use a builder with native
-> nodes like we do in CI. See ["Set up remote builders" step](.github/workflows/.build.yml)
+> nodes like we do in CI. See ["Set up remote builders" step](.github/workflows/release.yml)
 > for more details.
 
 If you just want to build packages only for your current platform, you can set

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ to request changes to the packaging process.
 ## About
 
 This repository creates packages (apk, deb, rpm, static) for various projects
-and are published as a Docker image on Docker Hub.
+and are published as a Docker image [on Docker Hub](https://hub.docker.com/r/dockereng/packaging).
 
 ## Prerequisites
 
@@ -83,276 +83,118 @@ to extract packages:
 
 ```shell
 # extract packages for all platforms and output to ./bin/undock folder
-$ undock --wrap --rm-dist --all dockereng/packaging:buildx-v0.9.1 ./bin/undock
+$ undock --wrap --rm-dist --all dockereng/packaging:buildx-v0.9.1 ./buildx/v0.9.1
 ```
 
 <details>
   <summary>tree ./bin/undock</summary>
 
 ```
-./bin/undock/
-├── alpine
-│   ├── 3.14
-│   │   ├── amd64
-│   │   │   └── docker-buildx-plugin_0.9.1-0_x86_64.apk
-│   │   ├── arm
-│   │   │   ├── v6
-│   │   │   │   └── docker-buildx-plugin_0.9.1-0_armhf.apk
-│   │   │   └── v7
-│   │   │       └── docker-buildx-plugin_0.9.1-0_armv7.apk
-│   │   ├── arm64
-│   │   │   └── docker-buildx-plugin_0.9.1-0_aarch64.apk
-│   │   ├── ppc64le
-│   │   │   └── docker-buildx-plugin_0.9.1-0_ppc64le.apk
-│   │   ├── riscv64
-│   │   │   └── docker-buildx-plugin_0.9.1-0_riscv64.apk
-│   │   └── s390x
-│   │       └── docker-buildx-plugin_0.9.1-0_s390x.apk
-│   ├── 3.15
-│   │   ├── amd64
-│   │   │   └── docker-buildx-plugin_0.9.1-0_x86_64.apk
-│   │   ├── arm
-│   │   │   ├── v6
-│   │   │   │   └── docker-buildx-plugin_0.9.1-0_armhf.apk
-│   │   │   └── v7
-│   │   │       └── docker-buildx-plugin_0.9.1-0_armv7.apk
-│   │   ├── arm64
-│   │   │   └── docker-buildx-plugin_0.9.1-0_aarch64.apk
-│   │   ├── ppc64le
-│   │   │   └── docker-buildx-plugin_0.9.1-0_ppc64le.apk
-│   │   ├── riscv64
-│   │   │   └── docker-buildx-plugin_0.9.1-0_riscv64.apk
-│   │   └── s390x
-│   │       └── docker-buildx-plugin_0.9.1-0_s390x.apk
-│   └── 3.16
-│       ├── amd64
-│       │   └── docker-buildx-plugin_0.9.1-0_x86_64.apk
-│       ├── arm
-│       │   ├── v6
-│       │   │   └── docker-buildx-plugin_0.9.1-0_armhf.apk
-│       │   └── v7
-│       │       └── docker-buildx-plugin_0.9.1-0_armv7.apk
-│       ├── arm64
-│       │   └── docker-buildx-plugin_0.9.1-0_aarch64.apk
-│       ├── ppc64le
-│       │   └── docker-buildx-plugin_0.9.1-0_ppc64le.apk
-│       ├── riscv64
-│       │   └── docker-buildx-plugin_0.9.1-0_riscv64.apk
-│       └── s390x
-│           └── docker-buildx-plugin_0.9.1-0_s390x.apk
+./buildx/v0.9.1/
 ├── centos
 │   ├── 7
 │   │   ├── amd64
-│   │   │   └── docker-buildx-plugin-0.9.1-0.x86_64.rpm
-│   │   ├── arm
-│   │   │   ├── v6
-│   │   │   │   └── docker-buildx-plugin-0.9.1-0.armv6hl.rpm
-│   │   │   └── v7
-│   │   │       └── docker-buildx-plugin-0.9.1-0.armv7hl.rpm
-│   │   ├── arm64
-│   │   │   └── docker-buildx-plugin-0.9.1-0.aarch64.rpm
-│   │   ├── ppc64le
-│   │   │   └── docker-buildx-plugin-0.9.1-0.ppc64le.rpm
-│   │   ├── riscv64
-│   │   │   └── docker-buildx-plugin-0.9.1-0.riscv64.rpm
-│   │   └── s390x
-│   │       └── docker-buildx-plugin-0.9.1-0.s390x.rpm
+│   │   │   └── docker-buildx-plugin-0.9.1-1.el7.x86_64.rpm
+│   │   └── arm64
+│   │       └── docker-buildx-plugin-0.9.1-1.el7.aarch64.rpm
 │   ├── 8
 │   │   ├── amd64
-│   │   │   └── docker-buildx-plugin-0.9.1-0.x86_64.rpm
-│   │   ├── arm
-│   │   │   ├── v6
-│   │   │   │   └── docker-buildx-plugin-0.9.1-0.armv6hl.rpm
-│   │   │   └── v7
-│   │   │       └── docker-buildx-plugin-0.9.1-0.armv7hl.rpm
-│   │   ├── arm64
-│   │   │   └── docker-buildx-plugin-0.9.1-0.aarch64.rpm
-│   │   ├── ppc64le
-│   │   │   └── docker-buildx-plugin-0.9.1-0.ppc64le.rpm
-│   │   ├── riscv64
-│   │   │   └── docker-buildx-plugin-0.9.1-0.riscv64.rpm
-│   │   └── s390x
-│   │       └── docker-buildx-plugin-0.9.1-0.s390x.rpm
+│   │   │   └── docker-buildx-plugin-0.9.1-1.el8.x86_64.rpm
+│   │   └── arm64
+│   │       └── docker-buildx-plugin-0.9.1-1.el8.aarch64.rpm
 │   └── 9
 │       ├── amd64
-│       │   └── docker-buildx-plugin-0.9.1-0.x86_64.rpm
-│       ├── arm
-│       │   ├── v6
-│       │   │   └── docker-buildx-plugin-0.9.1-0.armv6hl.rpm
-│       │   └── v7
-│       │       └── docker-buildx-plugin-0.9.1-0.armv7hl.rpm
-│       ├── arm64
-│       │   └── docker-buildx-plugin-0.9.1-0.aarch64.rpm
-│       ├── ppc64le
-│       │   └── docker-buildx-plugin-0.9.1-0.ppc64le.rpm
-│       ├── riscv64
-│       │   └── docker-buildx-plugin-0.9.1-0.riscv64.rpm
-│       └── s390x
-│           └── docker-buildx-plugin-0.9.1-0.s390x.rpm
+│       │   └── docker-buildx-plugin-0.9.1-1.el9.x86_64.rpm
+│       └── arm64
+│           └── docker-buildx-plugin-0.9.1-1.el9.aarch64.rpm
 ├── debian
 │   ├── bullseye
 │   │   ├── amd64
+│   │   │   ├── docker-buildx-plugin_0.9.1-0_amd64.buildinfo
+│   │   │   ├── docker-buildx-plugin_0.9.1-0_amd64.changes
 │   │   │   └── docker-buildx-plugin_0.9.1-0_amd64.deb
 │   │   ├── arm
 │   │   │   ├── v6
+│   │   │   │   ├── docker-buildx-plugin_0.9.1-0_armel.buildinfo
+│   │   │   │   ├── docker-buildx-plugin_0.9.1-0_armel.changes
 │   │   │   │   └── docker-buildx-plugin_0.9.1-0_armel.deb
 │   │   │   └── v7
+│   │   │       ├── docker-buildx-plugin_0.9.1-0_armhf.buildinfo
+│   │   │       ├── docker-buildx-plugin_0.9.1-0_armhf.changes
 │   │   │       └── docker-buildx-plugin_0.9.1-0_armhf.deb
 │   │   ├── arm64
+│   │   │   ├── docker-buildx-plugin_0.9.1-0_arm64.buildinfo
+│   │   │   ├── docker-buildx-plugin_0.9.1-0_arm64.changes
 │   │   │   └── docker-buildx-plugin_0.9.1-0_arm64.deb
-│   │   ├── ppc64le
-│   │   │   └── docker-buildx-plugin_0.9.1-0_ppc64el.deb
-│   │   ├── riscv64
-│   │   │   └── docker-buildx-plugin_0.9.1-0_riscv64.deb
 │   │   └── s390x
+│   │       ├── docker-buildx-plugin_0.9.1-0_s390x.buildinfo
+│   │       ├── docker-buildx-plugin_0.9.1-0_s390x.changes
 │   │       └── docker-buildx-plugin_0.9.1-0_s390x.deb
 │   └── buster
 │       ├── amd64
+│       │   ├── docker-buildx-plugin_0.9.1-0_amd64.buildinfo
+│       │   ├── docker-buildx-plugin_0.9.1-0_amd64.changes
 │       │   └── docker-buildx-plugin_0.9.1-0_amd64.deb
 │       ├── arm
-│       │   ├── v6
-│       │   │   └── docker-buildx-plugin_0.9.1-0_armel.deb
 │       │   └── v7
+│       │       ├── docker-buildx-plugin_0.9.1-0_armhf.buildinfo
+│       │       ├── docker-buildx-plugin_0.9.1-0_armhf.changes
 │       │       └── docker-buildx-plugin_0.9.1-0_armhf.deb
-│       ├── arm64
-│       │   └── docker-buildx-plugin_0.9.1-0_arm64.deb
-│       ├── ppc64le
-│       │   └── docker-buildx-plugin_0.9.1-0_ppc64el.deb
-│       ├── riscv64
-│       │   └── docker-buildx-plugin_0.9.1-0_riscv64.deb
-│       └── s390x
-│           └── docker-buildx-plugin_0.9.1-0_s390x.deb
+│       └── arm64
+│           ├── docker-buildx-plugin_0.9.1-0_arm64.buildinfo
+│           ├── docker-buildx-plugin_0.9.1-0_arm64.changes
+│           └── docker-buildx-plugin_0.9.1-0_arm64.deb
 ├── fedora
 │   ├── 35
 │   │   ├── amd64
-│   │   │   └── docker-buildx-plugin-0.9.1-0.x86_64.rpm
-│   │   ├── arm
-│   │   │   ├── v6
-│   │   │   │   └── docker-buildx-plugin-0.9.1-0.armv6hl.rpm
-│   │   │   └── v7
-│   │   │       └── docker-buildx-plugin-0.9.1-0.armv7hl.rpm
+│   │   │   └── docker-buildx-plugin-0.9.1-1.fc35.x86_64.rpm
 │   │   ├── arm64
-│   │   │   └── docker-buildx-plugin-0.9.1-0.aarch64.rpm
-│   │   ├── ppc64le
-│   │   │   └── docker-buildx-plugin-0.9.1-0.ppc64le.rpm
-│   │   ├── riscv64
-│   │   │   └── docker-buildx-plugin-0.9.1-0.riscv64.rpm
+│   │   │   └── docker-buildx-plugin-0.9.1-1.fc35.aarch64.rpm
 │   │   └── s390x
-│   │       └── docker-buildx-plugin-0.9.1-0.s390x.rpm
+│   │       └── docker-buildx-plugin-0.9.1-1.fc35.s390x.rpm
 │   ├── 36
 │   │   ├── amd64
-│   │   │   └── docker-buildx-plugin-0.9.1-0.x86_64.rpm
-│   │   ├── arm
-│   │   │   ├── v6
-│   │   │   │   └── docker-buildx-plugin-0.9.1-0.armv6hl.rpm
-│   │   │   └── v7
-│   │   │       └── docker-buildx-plugin-0.9.1-0.armv7hl.rpm
+│   │   │   └── docker-buildx-plugin-0.9.1-1.fc36.x86_64.rpm
 │   │   ├── arm64
-│   │   │   └── docker-buildx-plugin-0.9.1-0.aarch64.rpm
-│   │   ├── ppc64le
-│   │   │   └── docker-buildx-plugin-0.9.1-0.ppc64le.rpm
-│   │   ├── riscv64
-│   │   │   └── docker-buildx-plugin-0.9.1-0.riscv64.rpm
+│   │   │   └── docker-buildx-plugin-0.9.1-1.fc36.aarch64.rpm
 │   │   └── s390x
-│   │       └── docker-buildx-plugin-0.9.1-0.s390x.rpm
+│   │       └── docker-buildx-plugin-0.9.1-1.fc36.s390x.rpm
 │   └── 37
 │       ├── amd64
-│       │   └── docker-buildx-plugin-0.9.1-0.x86_64.rpm
-│       ├── arm
-│       │   ├── v6
-│       │   │   └── docker-buildx-plugin-0.9.1-0.armv6hl.rpm
-│       │   └── v7
-│       │       └── docker-buildx-plugin-0.9.1-0.armv7hl.rpm
+│       │   └── docker-buildx-plugin-0.9.1-1.fc37.x86_64.rpm
 │       ├── arm64
-│       │   └── docker-buildx-plugin-0.9.1-0.aarch64.rpm
-│       ├── ppc64le
-│       │   └── docker-buildx-plugin-0.9.1-0.ppc64le.rpm
-│       ├── riscv64
-│       │   └── docker-buildx-plugin-0.9.1-0.riscv64.rpm
+│       │   └── docker-buildx-plugin-0.9.1-1.fc37.aarch64.rpm
 │       └── s390x
-│           └── docker-buildx-plugin-0.9.1-0.s390x.rpm
+│           └── docker-buildx-plugin-0.9.1-1.fc37.s390x.rpm
 ├── oraclelinux
 │   ├── 7
 │   │   ├── amd64
-│   │   │   └── docker-buildx-plugin-0.9.1-0.x86_64.rpm
-│   │   ├── arm
-│   │   │   ├── v6
-│   │   │   │   └── docker-buildx-plugin-0.9.1-0.armv6hl.rpm
-│   │   │   └── v7
-│   │   │       └── docker-buildx-plugin-0.9.1-0.armv7hl.rpm
-│   │   ├── arm64
-│   │   │   └── docker-buildx-plugin-0.9.1-0.aarch64.rpm
-│   │   ├── ppc64le
-│   │   │   └── docker-buildx-plugin-0.9.1-0.ppc64le.rpm
-│   │   ├── riscv64
-│   │   │   └── docker-buildx-plugin-0.9.1-0.riscv64.rpm
-│   │   └── s390x
-│   │       └── docker-buildx-plugin-0.9.1-0.s390x.rpm
+│   │   │   └── docker-buildx-plugin-0.9.1-1.el7.x86_64.rpm
+│   │   └── arm64
+│   │       └── docker-buildx-plugin-0.9.1-1.el7.aarch64.rpm
 │   ├── 8
 │   │   ├── amd64
-│   │   │   └── docker-buildx-plugin-0.9.1-0.x86_64.rpm
-│   │   ├── arm
-│   │   │   ├── v6
-│   │   │   │   └── docker-buildx-plugin-0.9.1-0.armv6hl.rpm
-│   │   │   └── v7
-│   │   │       └── docker-buildx-plugin-0.9.1-0.armv7hl.rpm
-│   │   ├── arm64
-│   │   │   └── docker-buildx-plugin-0.9.1-0.aarch64.rpm
-│   │   ├── ppc64le
-│   │   │   └── docker-buildx-plugin-0.9.1-0.ppc64le.rpm
-│   │   ├── riscv64
-│   │   │   └── docker-buildx-plugin-0.9.1-0.riscv64.rpm
-│   │   └── s390x
-│   │       └── docker-buildx-plugin-0.9.1-0.s390x.rpm
+│   │   │   └── docker-buildx-plugin-0.9.1-1.el8.x86_64.rpm
+│   │   └── arm64
+│   │       └── docker-buildx-plugin-0.9.1-1.el8.aarch64.rpm
 │   └── 9
 │       ├── amd64
-│       │   └── docker-buildx-plugin-0.9.1-0.x86_64.rpm
-│       ├── arm
-│       │   ├── v6
-│       │   │   └── docker-buildx-plugin-0.9.1-0.armv6hl.rpm
-│       │   └── v7
-│       │       └── docker-buildx-plugin-0.9.1-0.armv7hl.rpm
-│       ├── arm64
-│       │   └── docker-buildx-plugin-0.9.1-0.aarch64.rpm
-│       ├── ppc64le
-│       │   └── docker-buildx-plugin-0.9.1-0.ppc64le.rpm
-│       ├── riscv64
-│       │   └── docker-buildx-plugin-0.9.1-0.riscv64.rpm
-│       └── s390x
-│           └── docker-buildx-plugin-0.9.1-0.s390x.rpm
+│       │   └── docker-buildx-plugin-0.9.1-1.el9.x86_64.rpm
+│       └── arm64
+│           └── docker-buildx-plugin-0.9.1-1.el9.aarch64.rpm
 ├── raspbian
 │   ├── bullseye
-│   │   ├── amd64
-│   │   │   └── docker-buildx-plugin_0.9.1-0_amd64.deb
-│   │   ├── arm
-│   │   │   ├── v6
-│   │   │   │   └── docker-buildx-plugin_0.9.1-0_armel.deb
-│   │   │   └── v7
-│   │   │       └── docker-buildx-plugin_0.9.1-0_armhf.deb
-│   │   ├── arm64
-│   │   │   └── docker-buildx-plugin_0.9.1-0_arm64.deb
-│   │   ├── ppc64le
-│   │   │   └── docker-buildx-plugin_0.9.1-0_ppc64el.deb
-│   │   ├── riscv64
-│   │   │   └── docker-buildx-plugin_0.9.1-0_riscv64.deb
-│   │   └── s390x
-│   │       └── docker-buildx-plugin_0.9.1-0_s390x.deb
+│   │   └── arm
+│   │       └── v7
+│   │           ├── docker-buildx-plugin_0.9.1-0_armhf.buildinfo
+│   │           ├── docker-buildx-plugin_0.9.1-0_armhf.changes
+│   │           └── docker-buildx-plugin_0.9.1-0_armhf.deb
 │   └── buster
-│       ├── amd64
-│       │   └── docker-buildx-plugin_0.9.1-0_amd64.deb
-│       ├── arm
-│       │   ├── v6
-│       │   │   └── docker-buildx-plugin_0.9.1-0_armel.deb
-│       │   └── v7
-│       │       └── docker-buildx-plugin_0.9.1-0_armhf.deb
-│       ├── arm64
-│       │   └── docker-buildx-plugin_0.9.1-0_arm64.deb
-│       ├── ppc64le
-│       │   └── docker-buildx-plugin_0.9.1-0_ppc64el.deb
-│       ├── riscv64
-│       │   └── docker-buildx-plugin_0.9.1-0_riscv64.deb
-│       └── s390x
-│           └── docker-buildx-plugin_0.9.1-0_s390x.deb
+│       └── arm
+│           └── v7
+│               ├── docker-buildx-plugin_0.9.1-0_armhf.buildinfo
+│               ├── docker-buildx-plugin_0.9.1-0_armhf.changes
+│               └── docker-buildx-plugin_0.9.1-0_armhf.deb
 ├── static
 │   ├── darwin
 │   │   ├── amd64
@@ -369,8 +211,6 @@ $ undock --wrap --rm-dist --all dockereng/packaging:buildx-v0.9.1 ./bin/undock
 │   │   │       └── docker-buildx-plugin_0.9.1.tgz
 │   │   ├── arm64
 │   │   │   └── docker-buildx-plugin_0.9.1.tgz
-│   │   ├── ppc64le
-│   │   │   └── docker-buildx-plugin_0.9.1.tgz
 │   │   ├── riscv64
 │   │   │   └── docker-buildx-plugin_0.9.1.tgz
 │   │   └── s390x
@@ -383,54 +223,60 @@ $ undock --wrap --rm-dist --all dockereng/packaging:buildx-v0.9.1 ./bin/undock
 └── ubuntu
     ├── bionic
     │   ├── amd64
+    │   │   ├── docker-buildx-plugin_0.9.1-0_amd64.buildinfo
+    │   │   ├── docker-buildx-plugin_0.9.1-0_amd64.changes
     │   │   └── docker-buildx-plugin_0.9.1-0_amd64.deb
     │   ├── arm
-    │   │   ├── v6
-    │   │   │   └── docker-buildx-plugin_0.9.1-0_armel.deb
     │   │   └── v7
+    │   │       ├── docker-buildx-plugin_0.9.1-0_armhf.buildinfo
+    │   │       ├── docker-buildx-plugin_0.9.1-0_armhf.changes
     │   │       └── docker-buildx-plugin_0.9.1-0_armhf.deb
     │   ├── arm64
+    │   │   ├── docker-buildx-plugin_0.9.1-0_arm64.buildinfo
+    │   │   ├── docker-buildx-plugin_0.9.1-0_arm64.changes
     │   │   └── docker-buildx-plugin_0.9.1-0_arm64.deb
-    │   ├── ppc64le
-    │   │   └── docker-buildx-plugin_0.9.1-0_ppc64el.deb
-    │   ├── riscv64
-    │   │   └── docker-buildx-plugin_0.9.1-0_riscv64.deb
     │   └── s390x
+    │       ├── docker-buildx-plugin_0.9.1-0_s390x.buildinfo
+    │       ├── docker-buildx-plugin_0.9.1-0_s390x.changes
     │       └── docker-buildx-plugin_0.9.1-0_s390x.deb
     ├── focal
     │   ├── amd64
+    │   │   ├── docker-buildx-plugin_0.9.1-0_amd64.buildinfo
+    │   │   ├── docker-buildx-plugin_0.9.1-0_amd64.changes
     │   │   └── docker-buildx-plugin_0.9.1-0_amd64.deb
     │   ├── arm
-    │   │   ├── v6
-    │   │   │   └── docker-buildx-plugin_0.9.1-0_armel.deb
     │   │   └── v7
+    │   │       ├── docker-buildx-plugin_0.9.1-0_armhf.buildinfo
+    │   │       ├── docker-buildx-plugin_0.9.1-0_armhf.changes
     │   │       └── docker-buildx-plugin_0.9.1-0_armhf.deb
     │   ├── arm64
+    │   │   ├── docker-buildx-plugin_0.9.1-0_arm64.buildinfo
+    │   │   ├── docker-buildx-plugin_0.9.1-0_arm64.changes
     │   │   └── docker-buildx-plugin_0.9.1-0_arm64.deb
-    │   ├── ppc64le
-    │   │   └── docker-buildx-plugin_0.9.1-0_ppc64el.deb
-    │   ├── riscv64
-    │   │   └── docker-buildx-plugin_0.9.1-0_riscv64.deb
     │   └── s390x
+    │       ├── docker-buildx-plugin_0.9.1-0_s390x.buildinfo
+    │       ├── docker-buildx-plugin_0.9.1-0_s390x.changes
     │       └── docker-buildx-plugin_0.9.1-0_s390x.deb
     └── jammy
         ├── amd64
+        │   ├── docker-buildx-plugin_0.9.1-0_amd64.buildinfo
+        │   ├── docker-buildx-plugin_0.9.1-0_amd64.changes
         │   └── docker-buildx-plugin_0.9.1-0_amd64.deb
         ├── arm
-        │   ├── v6
-        │   │   └── docker-buildx-plugin_0.9.1-0_armel.deb
         │   └── v7
+        │       ├── docker-buildx-plugin_0.9.1-0_armhf.buildinfo
+        │       ├── docker-buildx-plugin_0.9.1-0_armhf.changes
         │       └── docker-buildx-plugin_0.9.1-0_armhf.deb
         ├── arm64
+        │   ├── docker-buildx-plugin_0.9.1-0_arm64.buildinfo
+        │   ├── docker-buildx-plugin_0.9.1-0_arm64.changes
         │   └── docker-buildx-plugin_0.9.1-0_arm64.deb
-        ├── ppc64le
-        │   └── docker-buildx-plugin_0.9.1-0_ppc64el.deb
-        ├── riscv64
-        │   └── docker-buildx-plugin_0.9.1-0_riscv64.deb
         └── s390x
+            ├── docker-buildx-plugin_0.9.1-0_s390x.buildinfo
+            ├── docker-buildx-plugin_0.9.1-0_s390x.changes
             └── docker-buildx-plugin_0.9.1-0_s390x.deb
 
-194 directories, 144 files
+87 directories, 97 files
 ```
 </details>
 

--- a/pkg/buildx/Dockerfile
+++ b/pkg/buildx/Dockerfile
@@ -53,7 +53,7 @@ RUN apk add --no-cache bash curl file git zip tar
 FROM src-base AS src
 WORKDIR /src
 ARG BUILDX_REPO
-RUN git init . && git remote add origin "${BUILDX_REPO}"
+RUN git init . && git remote add origin "${BUILDX_REPO}.git"
 ARG BUILDX_VERSION
 RUN git fetch origin "${BUILDX_VERSION}" +refs/heads/*:refs/remotes/origin/* +refs/tags/*:refs/tags/* && git checkout -q FETCH_HEAD
 

--- a/pkg/buildx/Makefile
+++ b/pkg/buildx/Makefile
@@ -14,16 +14,21 @@
 
 include ../../common/vars.mk
 
-export BUILDX_REPO ?= https://github.com/docker/buildx.git
-export BUILDX_VERSION ?= v0.9.1
-
 DESTDIR ?= $(BASEDIR)/bin
 BAKE_DEFINITIONS ?= -f docker-bake.hcl -f ../../common/packages.hcl
+
+export BUILDX_REPO ?= https://github.com/docker/buildx
+export BUILDX_VERSION ?= v0.9.1
 
 PKG_LIST ?= deb rpm static
 # supported platforms: https://github.com/docker/buildx/blob/e98c2524905e659d34ac01cc328cd21c966be3f2/docker-bake.hcl#L112-L124
 # FIXME: add linux/ppc64le when a remote PowerPC instance is available (too slow with QEMU)
 PKG_PLATFORMS ?= darwin/amd64 darwin/arm64 linux/amd64 linux/arm/v6 linux/arm/v7 linux/arm64 linux/riscv64 linux/s390x windows/amd64 windows/arm64
+
+define PKG_SUMMARY
+* repo: $(BUILDX_REPO)
+* version: `$(BUILDX_VERSION)`
+endef
 
 .PHONY: all
 all: pkg
@@ -33,9 +38,18 @@ all: pkg
 all-%: pkg-%
 	@#
 
+.PHONY: repo
+repo:
+	@echo $(BUILDX_REPO)
+
 .PHONY: version
 version:
 	@echo $(BUILDX_VERSION)
+
+export PKG_SUMMARY
+.PHONY: summary
+summary:
+	@echo "$$PKG_SUMMARY"
 
 include ../../common/packages.mk
 include ../../common/build.mk

--- a/pkg/compose/Dockerfile
+++ b/pkg/compose/Dockerfile
@@ -53,7 +53,7 @@ RUN apk add --no-cache bash curl file git zip tar
 FROM src-base AS src
 WORKDIR /src
 ARG COMPOSE_REPO
-RUN git init . && git remote add origin "${COMPOSE_REPO}"
+RUN git init . && git remote add origin "${COMPOSE_REPO}.git"
 ARG COMPOSE_VERSION
 RUN git fetch origin "${COMPOSE_VERSION}" +refs/heads/*:refs/remotes/origin/* +refs/tags/*:refs/tags/* && git checkout -q FETCH_HEAD
 

--- a/pkg/compose/Makefile
+++ b/pkg/compose/Makefile
@@ -14,16 +14,21 @@
 
 include ../../common/vars.mk
 
-export COMPOSE_REPO ?= https://github.com/docker/compose.git
-export COMPOSE_VERSION ?= v2.10.2
-
 DESTDIR ?= $(BASEDIR)/bin
 BAKE_DEFINITIONS ?= -f docker-bake.hcl -f ../../common/packages.hcl
+
+export COMPOSE_REPO ?= https://github.com/docker/compose
+export COMPOSE_VERSION ?= v2.10.2
 
 PKG_LIST ?= deb rpm static
 # supported platforms: https://github.com/docker/compose/blob/e2a3fe94273b05a1428652ba248edeee4171427f/docker-bake.hcl#L95-L107
 # FIXME: add linux/ppc64le when a remote PowerPC instance is available (too slow with QEMU)
 PKG_PLATFORMS ?= darwin/amd64 darwin/arm64 linux/amd64 linux/arm/v6 linux/arm/v7 linux/arm64 linux/riscv64 linux/s390x windows/amd64 windows/arm64
+
+define PKG_SUMMARY
+* repo: $(COMPOSE_REPO)
+* version: `$(COMPOSE_VERSION)`
+endef
 
 .PHONY: all
 all: pkg
@@ -33,9 +38,18 @@ all: pkg
 all-%: pkg-%
 	@#
 
+.PHONY: repo
+repo:
+	@echo $(COMPOSE_REPO)
+
 .PHONY: version
 version:
 	@echo $(COMPOSE_VERSION)
+
+export PKG_SUMMARY
+.PHONY: summary
+summary:
+	@echo "$$PKG_SUMMARY"
 
 include ../../common/packages.mk
 include ../../common/build.mk

--- a/pkg/containerd/Dockerfile
+++ b/pkg/containerd/Dockerfile
@@ -62,7 +62,7 @@ RUN apk add --no-cache bash curl file git zip tar
 FROM src-base AS src
 WORKDIR /src
 ARG CONTAINERD_REPO
-RUN git init . && git remote add origin "${CONTAINERD_REPO}"
+RUN git init . && git remote add origin "${CONTAINERD_REPO}.git"
 ARG CONTAINERD_VERSION
 RUN git fetch origin "${CONTAINERD_VERSION}" +refs/heads/*:refs/remotes/origin/* +refs/tags/*:refs/tags/* && git checkout -q FETCH_HEAD
 
@@ -74,7 +74,7 @@ FROM src-base AS runc-src
 WORKDIR /src
 ARG RUNC_REPO
 ARG RUNC_VERSION
-RUN git init . && git remote add origin "${RUNC_REPO}"
+RUN git init . && git remote add origin "${RUNC_REPO}.git"
 RUN --mount=from=src,source=/src,target=/containerd <<EOT
   [ -z "$RUNC_VERSION" ] && RUNC_VERSION=$(cat /containerd/script/setup/runc-version)
   git fetch origin "$RUNC_VERSION" +refs/heads/*:refs/remotes/origin/* +refs/tags/*:refs/tags/* && git checkout -q FETCH_HEAD

--- a/pkg/containerd/Makefile
+++ b/pkg/containerd/Makefile
@@ -14,11 +14,14 @@
 
 include ../../common/vars.mk
 
-export CONTAINERD_REPO ?= https://github.com/containerd/containerd.git
-export CONTAINERD_VERSION ?= v1.6.8
-
 DESTDIR ?= $(BASEDIR)/bin
 BAKE_DEFINITIONS ?= -f docker-bake.hcl -f ../../common/packages.hcl
+
+export CONTAINERD_REPO ?= https://github.com/containerd/containerd
+export CONTAINERD_VERSION ?= v1.6.8
+export PKG_DEB_REVISION = 1
+export RUNC_REPO ?= https://github.com/opencontainers/runc
+export RUNC_VERSION ?=
 
 PKG_LIST ?= deb rpm static
 # supported platforms: https://github.com/containerd/containerd/blob/39f7cd73e7cc3e1d24f3557adfce5b68484136f7/.github/workflows/ci.yml#L131-L150
@@ -27,9 +30,12 @@ PKG_LIST ?= deb rpm static
 # FIXME: add linux/ppc64le when a remote PowerPC instance is available (too slow with QEMU)
 PKG_PLATFORMS ?= linux/amd64 linux/arm/v6 linux/arm/v7 linux/arm64 linux/s390x
 
-export RUNC_REPO ?= https://github.com/opencontainers/runc.git
-export RUNC_VERSION ?=
-export PKG_DEB_REVISION = 1
+define PKG_SUMMARY
+* containerd repo: $(CONTAINERD_REPO)
+* containerd version: `$(CONTAINERD_VERSION)`
+* runc repo: $(RUNC_REPO)
+* runc version: $(if $(RUNC_VERSION),$(RUNC_VERSION),_N/A_)
+endef
 
 .PHONY: all
 all: pkg
@@ -39,9 +45,18 @@ all: pkg
 all-%: pkg-%
 	@#
 
+.PHONY: repo
+repo:
+	@echo $(CONTAINERD_REPO)
+
 .PHONY: version
 version:
 	@echo $(CONTAINERD_VERSION)
+
+export PKG_SUMMARY
+.PHONY: summary
+summary:
+	@echo "$$PKG_SUMMARY"
 
 include ../../common/packages.mk
 include ../../common/build.mk

--- a/pkg/credential-helpers/Dockerfile
+++ b/pkg/credential-helpers/Dockerfile
@@ -56,7 +56,7 @@ RUN apk add --no-cache bash curl file git zip tar
 FROM src-base AS src
 WORKDIR /src
 ARG CREDENTIAL_HELPERS_REPO
-RUN git init . && git remote add origin "${CREDENTIAL_HELPERS_REPO}"
+RUN git init . && git remote add origin "${CREDENTIAL_HELPERS_REPO}.git"
 ARG CREDENTIAL_HELPERS_VERSION
 RUN git fetch origin "${CREDENTIAL_HELPERS_VERSION}" +refs/heads/*:refs/remotes/origin/* +refs/tags/*:refs/tags/* && git checkout -q FETCH_HEAD
 

--- a/pkg/credential-helpers/Makefile
+++ b/pkg/credential-helpers/Makefile
@@ -14,7 +14,7 @@
 
 include ../../common/vars.mk
 
-export CREDENTIAL_HELPERS_REPO ?= https://github.com/docker/docker-credential-helpers.git
+export CREDENTIAL_HELPERS_REPO ?= https://github.com/docker/docker-credential-helpers
 export CREDENTIAL_HELPERS_VERSION ?= v0.7.0
 
 DESTDIR ?= $(BASEDIR)/bin
@@ -25,6 +25,11 @@ PKG_LIST ?= deb rpm static
 # FIXME: add linux/ppc64le when a remote PowerPC instance is available (too slow with QEMU)
 PKG_PLATFORMS ?= darwin/amd64 darwin/arm64 linux/amd64 linux/arm/v6 linux/arm/v7 linux/arm64 linux/s390x windows/amd64
 
+define PKG_SUMMARY
+* repo: $(CREDENTIAL_HELPERS_REPO)
+* version: `$(CREDENTIAL_HELPERS_VERSION)`
+endef
+
 .PHONY: all
 all: pkg
 	@#
@@ -33,9 +38,18 @@ all: pkg
 all-%: pkg-%
 	@#
 
+.PHONY: repo
+repo:
+	@echo $(CREDENTIAL_HELPERS_REPO)
+
 .PHONY: version
 version:
 	@echo $(CREDENTIAL_HELPERS_VERSION)
+
+export PKG_SUMMARY
+.PHONY: summary
+summary:
+	@echo "$$PKG_SUMMARY"
 
 include ../../common/packages.mk
 include ../../common/build.mk

--- a/pkg/docker-cli/Dockerfile
+++ b/pkg/docker-cli/Dockerfile
@@ -59,7 +59,7 @@ RUN apk add --no-cache bash curl file git zip tar
 FROM src-base AS src
 WORKDIR /src
 ARG DOCKER_CLI_REPO
-RUN git init . && git remote add origin "${DOCKER_CLI_REPO}"
+RUN git init . && git remote add origin "${DOCKER_CLI_REPO}.git"
 ARG DOCKER_CLI_VERSION
 RUN git fetch origin "${DOCKER_CLI_VERSION}" +refs/heads/*:refs/remotes/origin/* +refs/tags/*:refs/tags/* && git checkout -q FETCH_HEAD
 

--- a/pkg/docker-cli/Makefile
+++ b/pkg/docker-cli/Makefile
@@ -14,19 +14,23 @@
 
 include ../../common/vars.mk
 
-export DOCKER_CLI_REPO ?= https://github.com/docker/cli.git
-export DOCKER_CLI_VERSION ?= v22.06.0-beta.0
-
 DESTDIR ?= $(BASEDIR)/bin
 BAKE_DEFINITIONS ?= -f docker-bake.hcl -f ../../common/packages.hcl
+
+export DOCKER_CLI_REPO ?= https://github.com/docker/cli
+export DOCKER_CLI_VERSION ?= v22.06.0-beta.0
+export PKG_DEB_REVISION = 3
+export PKG_RPM_RELEASE = 3
 
 PKG_LIST ?= deb rpm static
 # supported platforms: https://github.com/docker/cli/blob/3e9117b7e241439e314eaf6fe944b4019fbaa941/docker-bake.hcl#L65-L67
 # FIXME: add linux/ppc64le when a remote PowerPC instance is available (too slow with QEMU)
 PKG_PLATFORMS ?= darwin/amd64 darwin/arm64 linux/386 linux/amd64 linux/arm/v7 linux/arm64 linux/s390x windows/amd64
 
-export PKG_DEB_REVISION = 3
-export PKG_RPM_RELEASE = 3
+define PKG_SUMMARY
+* repo: $(DOCKER_CLI_REPO)
+* version: `$(DOCKER_CLI_VERSION)`
+endef
 
 .PHONY: all
 all: pkg
@@ -36,9 +40,18 @@ all: pkg
 all-%: pkg-%
 	@#
 
+.PHONY: repo
+repo:
+	@echo $(DOCKER_CLI_REPO)
+
 .PHONY: version
 version:
 	@echo $(DOCKER_CLI_VERSION)
+
+export PKG_SUMMARY
+.PHONY: summary
+summary:
+	@echo "$$PKG_SUMMARY"
 
 include ../../common/packages.mk
 include ../../common/build.mk

--- a/pkg/docker-engine/Dockerfile
+++ b/pkg/docker-engine/Dockerfile
@@ -59,7 +59,7 @@ RUN apk add --no-cache bash curl file git zip tar
 FROM src-base AS src
 WORKDIR /src
 ARG DOCKER_ENGINE_REPO
-RUN git init . && git remote add origin "${DOCKER_ENGINE_REPO}"
+RUN git init . && git remote add origin "${DOCKER_ENGINE_REPO}.git"
 ARG DOCKER_ENGINE_VERSION
 RUN git fetch origin "${DOCKER_ENGINE_VERSION}" +refs/heads/*:refs/remotes/origin/* +refs/tags/*:refs/tags/* && git checkout -q FETCH_HEAD
 

--- a/pkg/docker-engine/Makefile
+++ b/pkg/docker-engine/Makefile
@@ -14,19 +14,23 @@
 
 include ../../common/vars.mk
 
-export DOCKER_ENGINE_REPO ?= https://github.com/docker/docker.git
-export DOCKER_ENGINE_VERSION ?= v22.06.0-beta.0
-
 DESTDIR ?= $(BASEDIR)/bin
 BAKE_DEFINITIONS ?= -f docker-bake.hcl -f ../../common/packages.hcl
+
+export DOCKER_ENGINE_REPO ?= https://github.com/docker/docker
+export DOCKER_ENGINE_VERSION ?= v22.06.0-beta.0
+export PKG_DEB_REVISION = 3
+export PKG_RPM_RELEASE = 3
 
 PKG_LIST ?= deb rpm static
 # supported platforms: https://github.com/moby/moby/blob/0e873d5cd8b31c08e29ff2f790c19a2e9c4ee30a/.github/workflows/ci.yml#L65-L73
 # FIXME: add linux/ppc64le when a remote PowerPC instance is available (too slow with QEMU)
 PKG_PLATFORMS ?= linux/amd64 linux/arm/v7 linux/arm64 linux/s390x windows/amd64
 
-export PKG_DEB_REVISION = 3
-export PKG_RPM_RELEASE = 3
+define PKG_SUMMARY
+* repo: $(DOCKER_ENGINE_REPO)
+* version: `$(DOCKER_ENGINE_VERSION)`
+endef
 
 .PHONY: all
 all: pkg
@@ -36,9 +40,18 @@ all: pkg
 all-%: pkg-%
 	@#
 
+.PHONY: repo
+repo:
+	@echo $(DOCKER_ENGINE_REPO)
+
 .PHONY: version
 version:
 	@echo $(DOCKER_ENGINE_VERSION)
+
+export PKG_SUMMARY
+.PHONY: summary
+summary:
+	@echo "$$PKG_SUMMARY"
 
 include ../../common/packages.mk
 include ../../common/build.mk

--- a/pkg/sbom/Dockerfile
+++ b/pkg/sbom/Dockerfile
@@ -53,7 +53,7 @@ RUN apk add --no-cache bash curl file git zip tar
 FROM src-base AS src
 WORKDIR /src
 ARG SBOM_REPO
-RUN git init . && git remote add origin "${SBOM_REPO}"
+RUN git init . && git remote add origin "${SBOM_REPO}.git"
 ARG SBOM_VERSION
 RUN git fetch origin "${SBOM_VERSION}" +refs/heads/*:refs/remotes/origin/* +refs/tags/*:refs/tags/* && git checkout -q FETCH_HEAD
 

--- a/pkg/sbom/Makefile
+++ b/pkg/sbom/Makefile
@@ -14,15 +14,20 @@
 
 include ../../common/vars.mk
 
-export SBOM_REPO ?= https://github.com/docker/sbom-cli-plugin.git
-export SBOM_VERSION ?= v0.6.1
-
 DESTDIR ?= $(BASEDIR)/bin
 BAKE_DEFINITIONS ?= -f docker-bake.hcl -f ../../common/packages.hcl
+
+export SBOM_REPO ?= https://github.com/docker/sbom-cli-plugin
+export SBOM_VERSION ?= v0.6.1
 
 PKG_LIST ?= deb rpm static
 # supported platforms: https://github.com/docker/sbom-cli-plugin/blob/b17d47dc0b20061e7924e835716caef3c6cc6a46/.goreleaser.yaml#L7-L13
 PKG_PLATFORMS ?= darwin/amd64 darwin/arm64 linux/amd64 linux/arm64 windows/amd64 windows/arm64
+
+define PKG_SUMMARY
+* repo: $(SBOM_REPO)
+* version: `$(SBOM_VERSION)`
+endef
 
 .PHONY: all
 all: pkg
@@ -32,9 +37,18 @@ all: pkg
 all-%: pkg-%
 	@#
 
+.PHONY: repo
+repo:
+	@echo $(SBOM_REPO)
+
 .PHONY: version
 version:
 	@echo $(SBOM_VERSION)
+
+export PKG_SUMMARY
+.PHONY: summary
+summary:
+	@echo "$$PKG_SUMMARY"
 
 include ../../common/packages.mk
 include ../../common/build.mk

--- a/pkg/scan/Dockerfile
+++ b/pkg/scan/Dockerfile
@@ -53,7 +53,7 @@ RUN apk add --no-cache bash curl file git zip tar
 FROM src-base AS src
 WORKDIR /src
 ARG SCAN_REPO
-RUN git init . && git remote add origin "${SCAN_REPO}"
+RUN git init . && git remote add origin "${SCAN_REPO}.git"
 ARG SCAN_VERSION
 RUN git fetch origin "${SCAN_VERSION}" +refs/heads/*:refs/remotes/origin/* +refs/tags/*:refs/tags/* && git checkout -q FETCH_HEAD
 

--- a/pkg/scan/Makefile
+++ b/pkg/scan/Makefile
@@ -14,15 +14,20 @@
 
 include ../../common/vars.mk
 
-export SCAN_REPO ?= https://github.com/docker/scan-cli-plugin.git
-export SCAN_VERSION ?= v0.19.0
-
 DESTDIR ?= $(BASEDIR)/bin
 BAKE_DEFINITIONS ?= -f docker-bake.hcl -f ../../common/packages.hcl
+
+export SCAN_REPO ?= https://github.com/docker/scan-cli-plugin
+export SCAN_VERSION ?= v0.19.0
 
 PKG_LIST ?= deb rpm static
 # supported platforms: https://github.com/docker/scan-cli-plugin/blob/9c797021449e3192a46ba86730d6f0e5409b6614/builder.Makefile#L62-L67
 PKG_PLATFORMS ?= darwin/amd64 darwin/arm64 linux/amd64 linux/arm64 windows/amd64
+
+define PKG_SUMMARY
+* repo: $(SCAN_REPO)
+* version: `$(SCAN_VERSION)`
+endef
 
 .PHONY: all
 all: pkg
@@ -32,9 +37,18 @@ all: pkg
 all-%: pkg-%
 	@#
 
+.PHONY: repo
+repo:
+	@echo $(SCAN_REPO)
+
 .PHONY: version
 version:
 	@echo $(SCAN_VERSION)
+
+export PKG_SUMMARY
+.PHONY: summary
+summary:
+	@echo "$$PKG_SUMMARY"
 
 include ../../common/packages.mk
 include ../../common/build.mk


### PR DESCRIPTION
also sets additional metadata like build result, summary and packages list in release body.

preview: https://github.com/crazy-max/docker-packaging/releases/tag/buildx%2Fv0.9.1-9