### PR TITLE
ci(release): ignore artifacts not found

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,7 @@ jobs:
         with:
           name: ${{ inputs.package }}
           path: ./pkg/${{ inputs.package }}/bin/*
-          if-no-files-found: error
+          if-no-files-found: ignore
           retention-days: 1
 
   release:


### PR DESCRIPTION
This happens for some packages like `sbom` and `scan` which do not support the `linux/arm/v7` platform and therefore `raspbian` packages will not build.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>