### PR TITLE
pkg: additional platforms support for docker-cli and docker-engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ to request changes to the packaging process.
 This repository creates packages (apk, deb, rpm, static) for various projects
 and are published as a Docker image [on Docker Hub](https://hub.docker.com/r/dockereng/packaging).
 
+___
+
+* [Prerequisites](#prerequisites)
+* [Supported tags](#supported-tags)
+* [Usage](#usage)
+* [Contributing](#contributing)
+
 ## Prerequisites
 
 Before building packages, you need to have `docker` and [Buildx CLI plugin](https://docs.docker.com/build/buildx/install/)
@@ -27,11 +34,21 @@ $ docker buildx create --driver docker-container --name mybuilder --use --bootst
 >
 > Some packages don't have cross-compilation support and therefore QEMU will
 > be used. As it can be slow, it is recommended to use a builder with native
-> nodes like we do in CI. See ["Set up remote builders" step](.github/workflows/release.yml)
+> nodes like we do in CI. See ["Set up remote builders" step](.github/workflows/.release.yml)
 > for more details.
 
-If you just want to build packages for your current platform, you can set
+If you just want to build packages for the current platform, you can set
 `LOCAL_PLATFORM=1` environment variable.
+
+## Supported tags
+
+See [GitHub Releases](https://github.com/docker/packaging/releases) for the
+list of published Docker tags.
+
+> **Note**
+>
+> We are also publishing nightly builds using the
+> [`<project>/nightly/<version>` tags](https://hub.docker.com/r/dockereng/packaging/tags?page=1&name=%2Fnightly%2F).
 
 ## Usage
 

--- a/common/scripts/fix-cc.sh
+++ b/common/scripts/fix-cc.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 Docker Packaging authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# FIXME: Workaround to verify toolchain's CC actually exists. Can be set to cross in official Go release: https://github.com/docker/packaging/pull/25#issuecomment-1256594482
+if ! which "$(go env CC)" &> /dev/null; then
+  go env -w CC=gcc
+fi

--- a/common/scripts/gen-ver.sh
+++ b/common/scripts/gen-ver.sh
@@ -20,7 +20,7 @@ if [ -z "$srcdir" ]; then
   exit 1
 fi
 
-version=$(git -C "${srcdir}" describe --match 'v[0-9]*' --dirty='-dev' --always --tags)
+version=$(git -C "${srcdir}" describe --match 'v[0-9]*' --always --tags)
 commit="$(git --git-dir "${srcdir}/.git" rev-parse HEAD)"
 commitShort=${commit:0:7}
 

--- a/pkg/buildx/Dockerfile
+++ b/pkg/buildx/Dockerfile
@@ -101,6 +101,7 @@ ARG PKG_DEB_EPOCH
 ARG SOURCE_DATE_EPOCH
 RUN --mount=type=bind,source=scripts/pkg-deb-build.sh,target=/usr/local/bin/pkg-deb-build \
     --mount=type=bind,from=common-scripts,source=gen-ver.sh,target=/usr/local/bin/gen-ver \
+    --mount=type=bind,from=common-scripts,source=fix-cc.sh,target=/usr/local/bin/fix-cc \
     --mount=type=bind,from=src,source=/src,target=/root/package/buildx,rw \
     --mount=type=bind,from=go,source=/usr/local/go,target=/usr/local/go \
     OUTDIR=/out SRCDIR=./buildx pkg-deb-build
@@ -143,6 +144,7 @@ ARG PKG_RPM_RELEASE
 ARG SOURCE_DATE_EPOCH
 RUN --mount=type=bind,source=scripts/pkg-rpm-build.sh,target=/usr/local/bin/pkg-rpm-build \
     --mount=type=bind,from=common-scripts,source=gen-ver.sh,target=/usr/local/bin/gen-ver \
+    --mount=type=bind,from=common-scripts,source=fix-cc.sh,target=/usr/local/bin/fix-cc \
     --mount=type=bind,from=src-tgz,source=/out/buildx.tgz,target=/root/rpmbuild/SOURCES/buildx.tgz \
     --mount=type=bind,from=src,source=/src,target=/usr/local/src/buildx \
     --mount=type=bind,from=go,source=/usr/local/go,target=/usr/local/go \
@@ -164,6 +166,7 @@ WORKDIR /build
 ARG TARGETPLATFORM
 RUN --mount=type=bind,source=scripts/pkg-static-build.sh,target=/usr/local/bin/pkg-static-build \
     --mount=type=bind,from=common-scripts,source=gen-ver.sh,target=/usr/local/bin/gen-ver \
+    --mount=type=bind,from=common-scripts,source=fix-cc.sh,target=/usr/local/bin/fix-cc \
     --mount=type=bind,from=src,source=/src,target=/usr/local/src/buildx \
     --mount=type=bind,from=gocross,source=/usr/local/go,target=/usr/local/go,rw \
     OUTDIR=/out BUILDDIR=/build SRCDIR=/usr/local/src/buildx pkg-static-build

--- a/pkg/buildx/scripts/pkg-deb-build.sh
+++ b/pkg/buildx/scripts/pkg-deb-build.sh
@@ -51,11 +51,7 @@ for l in $(gen-ver "${SRCDIR}"); do
 done
 
 xx-go --wrap
-
-# FIXME: CC is set to a cross package in Go release: https://github.com/docker/packaging/pull/25#issuecomment-1256594482
-if [ "$(go env CC)" = "$(xx-info triple)-gcc" ] && ! command "$(go env CC)" &> /dev/null; then
-  go env -w CC=gcc
-fi
+fix-cc
 
 cat > "debian/changelog" <<-EOF
 ${PKG_NAME} (${PKG_DEB_EPOCH}$([ -n "$PKG_DEB_EPOCH" ] && echo ":")${GENVER_PKG_VERSION}-${PKG_DEB_REVISION}) $PKG_SUITE; urgency=low

--- a/pkg/buildx/scripts/pkg-rpm-build.sh
+++ b/pkg/buildx/scripts/pkg-rpm-build.sh
@@ -50,11 +50,7 @@ for l in $(gen-ver "${SRCDIR}"); do
 done
 
 xx-go --wrap
-
-# FIXME: CC is set to a cross package in Go release: https://github.com/docker/packaging/pull/25#issuecomment-1256594482
-if [ "$(go env CC)" = "$(xx-info triple)-gcc" ] && ! command "$(go env CC)" &> /dev/null; then
-  go env -w CC=gcc
-fi
+fix-cc
 
 rpmDefine=(
   --define "_version ${GENVER_PKG_VERSION}"

--- a/pkg/buildx/scripts/pkg-static-build.sh
+++ b/pkg/buildx/scripts/pkg-static-build.sh
@@ -39,11 +39,7 @@ for l in $(gen-ver "${SRCDIR}"); do
 done
 
 xx-go --wrap
-
-# FIXME: CC is set to a cross package in Go release: https://github.com/docker/packaging/pull/25#issuecomment-1256594482
-if [ "$(go env CC)" = "$(xx-info triple)-gcc" ] && ! command "$(go env CC)" &> /dev/null; then
-  go env -w CC=gcc
-fi
+fix-cc
 
 binext=$([ "$(xx-info os)" = "windows" ] && echo ".exe" || true)
 pkg=github.com/docker/buildx

--- a/pkg/compose/Dockerfile
+++ b/pkg/compose/Dockerfile
@@ -101,6 +101,7 @@ ARG PKG_DEB_EPOCH
 ARG SOURCE_DATE_EPOCH
 RUN --mount=type=bind,source=scripts/pkg-deb-build.sh,target=/usr/local/bin/pkg-deb-build \
     --mount=type=bind,from=common-scripts,source=gen-ver.sh,target=/usr/local/bin/gen-ver \
+    --mount=type=bind,from=common-scripts,source=fix-cc.sh,target=/usr/local/bin/fix-cc \
     --mount=type=bind,from=src,source=/src,target=/root/package/compose,rw \
     --mount=type=bind,from=go,source=/usr/local/go,target=/usr/local/go \
     OUTDIR=/out SRCDIR=./compose pkg-deb-build
@@ -143,6 +144,7 @@ ARG PKG_RPM_RELEASE
 ARG SOURCE_DATE_EPOCH
 RUN --mount=type=bind,source=scripts/pkg-rpm-build.sh,target=/usr/local/bin/pkg-rpm-build \
     --mount=type=bind,from=common-scripts,source=gen-ver.sh,target=/usr/local/bin/gen-ver \
+    --mount=type=bind,from=common-scripts,source=fix-cc.sh,target=/usr/local/bin/fix-cc \
     --mount=type=bind,from=src-tgz,source=/out/compose.tgz,target=/root/rpmbuild/SOURCES/compose.tgz \
     --mount=type=bind,from=src,source=/src,target=/usr/local/src/compose \
     --mount=type=bind,from=go,source=/usr/local/go,target=/usr/local/go \
@@ -165,6 +167,7 @@ WORKDIR /build
 ARG TARGETPLATFORM
 RUN --mount=type=bind,source=scripts/pkg-static-build.sh,target=/usr/local/bin/pkg-static-build \
     --mount=type=bind,from=common-scripts,source=gen-ver.sh,target=/usr/local/bin/gen-ver \
+    --mount=type=bind,from=common-scripts,source=fix-cc.sh,target=/usr/local/bin/fix-cc \
     --mount=type=bind,from=src,source=/src,target=/usr/local/src/compose \
     --mount=type=bind,from=gocross,source=/usr/local/go,target=/usr/local/go,rw \
     OUTDIR=/out BUILDDIR=/build SRCDIR=/usr/local/src/compose pkg-static-build

--- a/pkg/compose/scripts/pkg-deb-build.sh
+++ b/pkg/compose/scripts/pkg-deb-build.sh
@@ -51,11 +51,7 @@ for l in $(gen-ver "${SRCDIR}"); do
 done
 
 xx-go --wrap
-
-# FIXME: CC is set to a cross package in Go release: https://github.com/docker/packaging/pull/25#issuecomment-1256594482
-if [ "$(go env CC)" = "$(xx-info triple)-gcc" ] && ! command "$(go env CC)" &> /dev/null; then
-  go env -w CC=gcc
-fi
+fix-cc
 
 cat > "debian/changelog" <<-EOF
 ${PKG_NAME} (${PKG_DEB_EPOCH}$([ -n "$PKG_DEB_EPOCH" ] && echo ":")${GENVER_PKG_VERSION}-${PKG_DEB_REVISION}) $PKG_SUITE; urgency=low

--- a/pkg/compose/scripts/pkg-rpm-build.sh
+++ b/pkg/compose/scripts/pkg-rpm-build.sh
@@ -50,11 +50,7 @@ for l in $(gen-ver "${SRCDIR}"); do
 done
 
 xx-go --wrap
-
-# FIXME: CC is set to a cross package in Go release: https://github.com/docker/packaging/pull/25#issuecomment-1256594482
-if [ "$(go env CC)" = "$(xx-info triple)-gcc" ] && ! command "$(go env CC)" &> /dev/null; then
-  go env -w CC=gcc
-fi
+fix-cc
 
 rpmDefine=(
   --define "_version ${GENVER_PKG_VERSION}"

--- a/pkg/compose/scripts/pkg-static-build.sh
+++ b/pkg/compose/scripts/pkg-static-build.sh
@@ -39,11 +39,7 @@ for l in $(gen-ver "${SRCDIR}"); do
 done
 
 xx-go --wrap
-
-# FIXME: CC is set to a cross package in Go release: https://github.com/docker/packaging/pull/25#issuecomment-1256594482
-if [ "$(go env CC)" = "$(xx-info triple)-gcc" ] && ! command "$(go env CC)" &> /dev/null; then
-  go env -w CC=gcc
-fi
+fix-cc
 
 binext=$([ "$(xx-info os)" = "windows" ] && echo ".exe" || true)
 

--- a/pkg/containerd/Dockerfile
+++ b/pkg/containerd/Dockerfile
@@ -136,6 +136,7 @@ ARG PKG_DEB_EPOCH
 ARG SOURCE_DATE_EPOCH
 RUN --mount=type=bind,source=scripts/pkg-deb-build.sh,target=/usr/local/bin/pkg-deb-build \
     --mount=type=bind,from=common-scripts,source=gen-ver.sh,target=/usr/local/bin/gen-ver \
+    --mount=type=bind,from=common-scripts,source=fix-cc.sh,target=/usr/local/bin/fix-cc \
     --mount=type=bind,source=common,target=/common,rw \
     --mount=type=bind,from=src,source=/src,target=/go/src/github.com/containerd/containerd,rw \
     --mount=type=bind,from=runc-src,source=/src,target=/go/src/github.com/opencontainers/runc,rw \
@@ -179,6 +180,7 @@ ARG PKG_RPM_RELEASE
 ARG SOURCE_DATE_EPOCH
 RUN --mount=type=bind,source=scripts/pkg-rpm-build.sh,target=/usr/local/bin/pkg-rpm-build \
     --mount=type=bind,from=common-scripts,source=gen-ver.sh,target=/usr/local/bin/gen-ver \
+    --mount=type=bind,from=common-scripts,source=fix-cc.sh,target=/usr/local/bin/fix-cc \
     --mount=type=bind,source=common/containerd.toml,target=/root/rpmbuild/SOURCES/containerd.toml \
     --mount=type=bind,from=src-tgz,source=/out/containerd.tgz,target=/root/rpmbuild/SOURCES/containerd.tgz \
     --mount=type=bind,from=runc-src-tgz,source=/out/runc.tgz,target=/root/rpmbuild/SOURCES/runc.tgz \
@@ -206,6 +208,7 @@ ARG TARGETPLATFORM
 RUN xx-apt-get install -y libbtrfs-dev libseccomp-dev btrfs-progs gcc
 RUN --mount=type=bind,source=scripts/pkg-static-build.sh,target=/usr/local/bin/pkg-static-build \
     --mount=type=bind,from=common-scripts,source=gen-ver.sh,target=/usr/local/bin/gen-ver \
+    --mount=type=bind,from=common-scripts,source=fix-cc.sh,target=/usr/local/bin/fix-cc \
     --mount=type=bind,from=src,source=/src,target=/go/src/github.com/containerd/containerd,rw \
     --mount=type=bind,from=runc-src,source=/src,target=/go/src/github.com/opencontainers/runc,rw \
     --mount=type=bind,from=gocross,source=/usr/local/go,target=/usr/local/go,rw \

--- a/pkg/containerd/scripts/pkg-deb-build.sh
+++ b/pkg/containerd/scripts/pkg-deb-build.sh
@@ -51,11 +51,7 @@ for l in $(gen-ver "${SRCDIR}"); do
 done
 
 xx-go --wrap
-
-# FIXME: CC is set to a cross package in Go release: https://github.com/docker/packaging/pull/25#issuecomment-1256594482
-if [ "$(go env CC)" = "$(xx-info triple)-gcc" ] && ! command "$(go env CC)" &> /dev/null; then
-  go env -w CC=gcc
-fi
+fix-cc
 
 if [ "$GENVER_VERSION" != "v$GENVER_PKG_VERSION" ]; then
   cat "debian/changelog" > "debian/changelog.or"

--- a/pkg/containerd/scripts/pkg-rpm-build.sh
+++ b/pkg/containerd/scripts/pkg-rpm-build.sh
@@ -50,11 +50,7 @@ for l in $(gen-ver "${SRCDIR}"); do
 done
 
 xx-go --wrap
-
-# FIXME: CC is set to a cross package in Go release: https://github.com/docker/packaging/pull/25#issuecomment-1256594482
-if [ "$(go env CC)" = "$(xx-info triple)-gcc" ] && ! command "$(go env CC)" &> /dev/null; then
-  go env -w CC=gcc
-fi
+fix-cc
 
 rpmDefine=(
   --define "_version ${GENVER_PKG_VERSION}"

--- a/pkg/containerd/scripts/pkg-static-build.sh
+++ b/pkg/containerd/scripts/pkg-static-build.sh
@@ -41,11 +41,7 @@ for l in $(gen-ver "${SRCDIR}"); do
 done
 
 xx-go --wrap
-
-# FIXME: CC is set to a cross package in Go release: https://github.com/docker/packaging/pull/25#issuecomment-1256594482
-if [ "$(go env CC)" = "$(xx-info triple)-gcc" ] && ! command "$(go env CC)" &> /dev/null; then
-  go env -w CC=gcc
-fi
+fix-cc
 
 # FIXME: should be built using clang but needs https://github.com/opencontainers/runc/pull/3465
 export CC=$(xx-info)-gcc

--- a/pkg/credential-helpers/Dockerfile
+++ b/pkg/credential-helpers/Dockerfile
@@ -102,6 +102,7 @@ ARG PKG_DEB_EPOCH
 ARG SOURCE_DATE_EPOCH
 RUN --mount=type=bind,source=scripts/pkg-deb-build.sh,target=/usr/local/bin/pkg-deb-build \
     --mount=type=bind,from=common-scripts,source=gen-ver.sh,target=/usr/local/bin/gen-ver \
+    --mount=type=bind,from=common-scripts,source=fix-cc.sh,target=/usr/local/bin/fix-cc \
     --mount=type=bind,from=src,source=/src,target=/root/package/docker-credential-helpers \
     --mount=type=bind,from=go,source=/usr/local/go,target=/usr/local/go \
     OUTDIR=/out SRCDIR=/root/package/docker-credential-helpers pkg-deb-build
@@ -142,6 +143,7 @@ ARG PKG_RPM_RELEASE
 ARG SOURCE_DATE_EPOCH
 RUN --mount=type=bind,source=scripts/pkg-rpm-build.sh,target=/usr/local/bin/pkg-rpm-build \
     --mount=type=bind,from=common-scripts,source=gen-ver.sh,target=/usr/local/bin/gen-ver \
+    --mount=type=bind,from=common-scripts,source=fix-cc.sh,target=/usr/local/bin/fix-cc \
     --mount=type=bind,from=src-tgz,source=/out/docker-credential-helpers.tgz,target=/root/rpmbuild/SOURCES/docker-credential-helpers.tgz \
     --mount=type=bind,from=src,source=/src,target=/usr/local/src/docker-credential-helpers \
     --mount=type=bind,from=go,source=/usr/local/go,target=/usr/local/go \
@@ -165,6 +167,7 @@ ARG TARGETPLATFORM
 RUN xx-apt-get install -y gcc libsecret-1-dev
 RUN --mount=type=bind,source=scripts/pkg-static-build.sh,target=/usr/local/bin/pkg-static-build \
     --mount=type=bind,from=common-scripts,source=gen-ver.sh,target=/usr/local/bin/gen-ver \
+    --mount=type=bind,from=common-scripts,source=fix-cc.sh,target=/usr/local/bin/fix-cc \
     --mount=type=bind,from=src,source=/src,target=/usr/local/src/credential-helpers \
     --mount=type=bind,from=gocross,source=/usr/local/go,target=/usr/local/go,rw \
     --mount=from=osxsdk,target=/xx-sdk,src=/xx-sdk \

--- a/pkg/credential-helpers/scripts/pkg-deb-build.sh
+++ b/pkg/credential-helpers/scripts/pkg-deb-build.sh
@@ -57,11 +57,7 @@ ${PKG_NAME} (${PKG_DEB_EPOCH}$([ -n "$PKG_DEB_EPOCH" ] && echo ":")${GENVER_PKG_
 EOF
 
 xx-go --wrap
-
-# FIXME: CC is set to a cross package in Go release: https://github.com/docker/packaging/pull/25#issuecomment-1256594482
-if [ "$(go env CC)" = "$(xx-info triple)-gcc" ] && ! command "$(go env CC)" &> /dev/null; then
-  go env -w CC=gcc
-fi
+fix-cc
 
 pkgoutput="${OUTDIR}/${PKG_DISTRO}/${PKG_SUITE}/$(xx-info arch)"
 if [ -n "$(xx-info variant)" ]; then

--- a/pkg/credential-helpers/scripts/pkg-rpm-build.sh
+++ b/pkg/credential-helpers/scripts/pkg-rpm-build.sh
@@ -50,11 +50,7 @@ for l in $(gen-ver "${SRCDIR}"); do
 done
 
 xx-go --wrap
-
-# FIXME: CC is set to a cross package in Go release: https://github.com/docker/packaging/pull/25#issuecomment-1256594482
-if [ "$(go env CC)" = "$(xx-info triple)-gcc" ] && ! command "$(go env CC)" &> /dev/null; then
-  go env -w CC=gcc
-fi
+fix-cc
 
 rpmDefine=(
   --define "_version ${GENVER_PKG_VERSION}"

--- a/pkg/credential-helpers/scripts/pkg-static-build.sh
+++ b/pkg/credential-helpers/scripts/pkg-static-build.sh
@@ -39,11 +39,7 @@ for l in $(gen-ver "${SRCDIR}"); do
 done
 
 xx-go --wrap
-
-# FIXME: CC is set to a cross package in Go release: https://github.com/docker/packaging/pull/25#issuecomment-1256594482
-if [ "$(go env CC)" = "$(xx-info triple)-gcc" ] && ! command "$(go env CC)" &> /dev/null; then
-  go env -w CC=gcc
-fi
+fix-cc
 
 case "$(xx-info os)" in
   darwin)

--- a/pkg/docker-cli/Dockerfile
+++ b/pkg/docker-cli/Dockerfile
@@ -116,6 +116,7 @@ ARG PKG_DEB_EPOCH
 ARG SOURCE_DATE_EPOCH
 RUN --mount=type=bind,source=scripts/pkg-deb-build.sh,target=/usr/local/bin/pkg-deb-build \
     --mount=type=bind,from=common-scripts,source=gen-ver.sh,target=/usr/local/bin/gen-ver \
+    --mount=type=bind,from=common-scripts,source=fix-cc.sh,target=/usr/local/bin/fix-cc \
     --mount=type=bind,from=src,source=/src,target=/root/package/cli,rw \
     --mount=type=bind,from=go,source=/usr/local/go,target=/usr/local/go \
     OUTDIR=/out SRCDIR=/root/package/cli pkg-deb-build
@@ -157,6 +158,7 @@ ARG PKG_RPM_RELEASE
 ARG SOURCE_DATE_EPOCH
 RUN --mount=type=bind,source=scripts/pkg-rpm-build.sh,target=/usr/local/bin/pkg-rpm-build \
     --mount=type=bind,from=common-scripts,source=gen-ver.sh,target=/usr/local/bin/gen-ver \
+    --mount=type=bind,from=common-scripts,source=fix-cc.sh,target=/usr/local/bin/fix-cc \
     --mount=type=bind,from=src-tgz,source=/out/cli.tgz,target=/root/rpmbuild/SOURCES/cli.tgz \
     --mount=type=bind,from=src,source=/src,target=/usr/local/src/cli \
     --mount=type=bind,from=go,source=/usr/local/go,target=/usr/local/go \
@@ -188,6 +190,7 @@ ARG TARGETPLATFORM
 RUN xx-apt-get install -y gcc libc6-dev
 RUN --mount=type=bind,source=scripts/pkg-static-build.sh,target=/usr/local/bin/pkg-static-build \
     --mount=type=bind,from=common-scripts,source=gen-ver.sh,target=/usr/local/bin/gen-ver \
+    --mount=type=bind,from=common-scripts,source=fix-cc.sh,target=/usr/local/bin/fix-cc \
     --mount=type=bind,from=src,source=/src,target=/go/src/github.com/docker/cli,rw \
     --mount=type=bind,from=gocross,source=/usr/local/go,target=/usr/local/go,rw \
     --mount=type=bind,from=goversioninfo,source=/out/goversioninfo,target=/usr/bin/goversioninfo \

--- a/pkg/docker-cli/Dockerfile
+++ b/pkg/docker-cli/Dockerfile
@@ -170,7 +170,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends bash ca-certifi
 ENV GOPROXY="https://proxy.golang.org|direct"
 ENV GOPATH="/go"
 ENV PATH="$PATH:/usr/local/go/bin:$GOPATH/bin"
-ENV CGO_ENABLED="1"
+ENV CGO_ENABLED="0"
+ENV GO111MODULE="off"
 
 FROM build-base-static AS goversioninfo
 ARG GOVERSIONINFO_VERSION
@@ -179,7 +180,7 @@ RUN --mount=type=bind,from=gocross,source=/usr/local/go,target=/usr/local/go,rw 
 
 FROM build-base-static AS builder-static
 ARG DEBIAN_FRONTEND
-RUN apt-get install -y --no-install-recommends dpkg-dev clang make pkg-config
+RUN apt-get install -y --no-install-recommends dpkg-dev clang lld llvm make pkg-config
 ARG PKG_NAME
 ARG DOCKER_CLI_REF
 WORKDIR /build

--- a/pkg/docker-cli/Makefile
+++ b/pkg/docker-cli/Makefile
@@ -26,7 +26,7 @@ export PKG_RPM_RELEASE = 3
 PKG_LIST ?= deb rpm static
 # supported platforms: https://github.com/docker/cli/blob/3e9117b7e241439e314eaf6fe944b4019fbaa941/docker-bake.hcl#L65-L67
 # FIXME: add linux/ppc64le when a remote PowerPC instance is available (too slow with QEMU)
-PKG_PLATFORMS ?= darwin/amd64 darwin/arm64 linux/386 linux/amd64 linux/arm/v7 linux/arm64 linux/s390x windows/amd64
+PKG_PLATFORMS ?= darwin/amd64 darwin/arm64 linux/386 linux/amd64 linux/arm/v6 linux/arm/v7 linux/arm64 linux/riscv64 linux/s390x windows/amd64 windows/arm64
 
 .PHONY: default
 default: pkg ;

--- a/pkg/docker-cli/docker-bake.hcl
+++ b/pkg/docker-cli/docker-bake.hcl
@@ -170,11 +170,14 @@ target "release" {
     "darwin/arm64",
     "linux/386",
     "linux/amd64",
+    "linux/arm/v6",
     "linux/arm/v7",
     "linux/arm64",
     "linux/ppc64le",
+    "linux/riscv64",
     "linux/s390x",
-    "windows/amd64"
+    "windows/amd64",
+    "windows/arm64"
   ]
   contexts = {
     bin-folder = "./bin"

--- a/pkg/docker-cli/scripts/pkg-deb-build.sh
+++ b/pkg/docker-cli/scripts/pkg-deb-build.sh
@@ -57,11 +57,7 @@ ${PKG_NAME} (${PKG_DEB_EPOCH}$([ -n "$PKG_DEB_EPOCH" ] && echo ":")${GENVER_PKG_
 EOF
 
 xx-go --wrap
-
-# FIXME: CC is set to a cross package in Go release: https://github.com/docker/packaging/pull/25#issuecomment-1256594482
-if [ "$(go env CC)" = "$(xx-info triple)-gcc" ] && ! command "$(go env CC)" &> /dev/null; then
-  go env -w CC=gcc
-fi
+fix-cc
 
 pkgoutput="${OUTDIR}/${PKG_DISTRO}/${PKG_SUITE}/$(xx-info arch)"
 if [ -n "$(xx-info variant)" ]; then

--- a/pkg/docker-cli/scripts/pkg-rpm-build.sh
+++ b/pkg/docker-cli/scripts/pkg-rpm-build.sh
@@ -50,11 +50,7 @@ for l in $(gen-ver "${SRCDIR}"); do
 done
 
 xx-go --wrap
-
-# FIXME: CC is set to a cross package in Go release: https://github.com/docker/packaging/pull/25#issuecomment-1256594482
-if [ "$(go env CC)" = "$(xx-info triple)-gcc" ] && ! command "$(go env CC)" &> /dev/null; then
-  go env -w CC=gcc
-fi
+fix-cc
 
 rpmDefine=(
   --define "_version ${GENVER_PKG_VERSION}"

--- a/pkg/docker-cli/scripts/pkg-static-build.sh
+++ b/pkg/docker-cli/scripts/pkg-static-build.sh
@@ -39,11 +39,7 @@ for l in $(gen-ver "${SRCDIR}"); do
 done
 
 xx-go --wrap
-
-# FIXME: CC is set to a cross package in Go release: https://github.com/docker/packaging/pull/25#issuecomment-1256594482
-if [ "$(go env CC)" = "$(xx-info triple)-gcc" ] && ! command "$(go env CC)" &> /dev/null; then
-  go env -w CC=gcc
-fi
+fix-cc
 
 # remove once llvm 12 available on debian
 # https://github.com/docker/cli/blob/65438e008c20a6125a1319eca07dcc3d7d4e38eb/Dockerfile#L30-L36

--- a/pkg/docker-cli/scripts/pkg-static-build.sh
+++ b/pkg/docker-cli/scripts/pkg-static-build.sh
@@ -45,6 +45,18 @@ if [ "$(go env CC)" = "$(xx-info triple)-gcc" ] && ! command "$(go env CC)" &> /
   go env -w CC=gcc
 fi
 
+# remove once llvm 12 available on debian
+# https://github.com/docker/cli/blob/65438e008c20a6125a1319eca07dcc3d7d4e38eb/Dockerfile#L30-L36
+if [ "$(xx-info os)/$(xx-info arch)" != "darwin/amd64" ]; then
+  ln -sfnT /bin/true /usr/bin/llvm-strip
+fi
+
+# prefer ld for cross-compiling arm64
+# https://github.com/docker/cli/pull/3493/commits/d45030380d8e1f8eadcb9512e81cfc63885aa638
+if [  "$(xx-info arch)" = "arm64" ]; then
+  XX_CC_PREFER_LINKER=ld xx-clang --setup-target-triple
+fi
+
 (
   set -x
   pushd ${SRCDIR}

--- a/pkg/docker-engine/Dockerfile
+++ b/pkg/docker-engine/Dockerfile
@@ -194,12 +194,12 @@ RUN --mount=type=bind,from=gocross,source=/usr/local/go,target=/usr/local/go,rw 
 
 FROM build-base-static AS builder-static
 ARG DEBIAN_FRONTEND
-RUN apt-get install -y --no-install-recommends dpkg-dev clang cmake make pkg-config
+RUN apt-get install -y --no-install-recommends cmake gcc libc6-dev lld make pkg-config
 ARG PKG_NAME
 ARG DOCKER_ENGINE_REF
 WORKDIR /build
 ARG TARGETPLATFORM
-RUN xx-apt-get install -y gcc libc6-dev libbtrfs-dev libdevmapper-dev libltdl-dev
+RUN xx-apt-get install -y gcc libc6-dev libapparmor-dev libbtrfs-dev libdevmapper-dev libltdl-dev libseccomp-dev libsecret-1-dev libsystemd-dev libudev-dev pkg-config
 RUN --mount=type=bind,source=scripts/pkg-static-build.sh,target=/usr/local/bin/pkg-static-build \
     --mount=type=bind,from=common-scripts,source=gen-ver.sh,target=/usr/local/bin/gen-ver \
     --mount=type=bind,from=src,source=/src,target=/go/src/github.com/docker/docker,rw \

--- a/pkg/docker-engine/Dockerfile
+++ b/pkg/docker-engine/Dockerfile
@@ -118,6 +118,7 @@ ARG PKG_DEB_EPOCH
 ARG SOURCE_DATE_EPOCH
 RUN --mount=type=bind,source=scripts/pkg-deb-build.sh,target=/usr/local/bin/pkg-deb-build \
     --mount=type=bind,from=common-scripts,source=gen-ver.sh,target=/usr/local/bin/gen-ver \
+    --mount=type=bind,from=common-scripts,source=fix-cc.sh,target=/usr/local/bin/fix-cc \
     --mount=source=common,target=/common \
     --mount=type=bind,from=src,source=/src,target=/root/package/engine,rw \
     --mount=type=bind,from=go,source=/usr/local/go,target=/usr/local/go \
@@ -169,6 +170,7 @@ ARG PKG_RPM_RELEASE
 ARG SOURCE_DATE_EPOCH
 RUN --mount=type=bind,source=scripts/pkg-rpm-build.sh,target=/usr/local/bin/pkg-rpm-build \
     --mount=type=bind,from=common-scripts,source=gen-ver.sh,target=/usr/local/bin/gen-ver \
+    --mount=type=bind,from=common-scripts,source=fix-cc.sh,target=/usr/local/bin/fix-cc \
     --mount=type=bind,source=common/systemd/docker.service,target=/root/rpmbuild/SOURCES/docker.service \
     --mount=type=bind,source=common/systemd/docker.socket,target=/root/rpmbuild/SOURCES/docker.socket \
     --mount=type=bind,from=src-tgz,source=/out/engine.tgz,target=/root/rpmbuild/SOURCES/engine.tgz \
@@ -202,6 +204,7 @@ ARG TARGETPLATFORM
 RUN xx-apt-get install -y gcc libc6-dev libapparmor-dev libbtrfs-dev libdevmapper-dev libltdl-dev libseccomp-dev libsecret-1-dev libsystemd-dev libudev-dev pkg-config
 RUN --mount=type=bind,source=scripts/pkg-static-build.sh,target=/usr/local/bin/pkg-static-build \
     --mount=type=bind,from=common-scripts,source=gen-ver.sh,target=/usr/local/bin/gen-ver \
+    --mount=type=bind,from=common-scripts,source=fix-cc.sh,target=/usr/local/bin/fix-cc \
     --mount=type=bind,from=src,source=/src,target=/go/src/github.com/docker/docker,rw \
     --mount=type=bind,from=gocross,source=/usr/local/go,target=/usr/local/go,rw \
     --mount=type=bind,from=gowinres,source=/out/go-winres,target=/usr/bin/go-winres \

--- a/pkg/docker-engine/Makefile
+++ b/pkg/docker-engine/Makefile
@@ -26,7 +26,7 @@ export PKG_RPM_RELEASE = 3
 PKG_LIST ?= deb rpm static
 # supported platforms: https://github.com/moby/moby/blob/0e873d5cd8b31c08e29ff2f790c19a2e9c4ee30a/.github/workflows/ci.yml#L65-L73
 # FIXME: add linux/ppc64le when a remote PowerPC instance is available (too slow with QEMU)
-PKG_PLATFORMS ?= linux/amd64 linux/arm/v7 linux/arm64 linux/s390x windows/amd64
+PKG_PLATFORMS ?= linux/amd64 linux/arm/v6 linux/arm/v7 linux/arm64 linux/s390x windows/amd64 windows/arm64
 
 .PHONY: default
 default: pkg ;

--- a/pkg/docker-engine/docker-bake.hcl
+++ b/pkg/docker-engine/docker-bake.hcl
@@ -167,11 +167,13 @@ target "release" {
   # same as PKG_PLATFORMS in Makefile
   platforms = [
     "linux/amd64",
+    "linux/arm/v6",
     "linux/arm/v7",
     "linux/arm64",
     "linux/ppc64le",
     "linux/s390x",
-    "windows/amd64"
+    "windows/amd64",
+    "windows/arm64"
   ]
   contexts = {
     bin-folder = "./bin"

--- a/pkg/docker-engine/scripts/pkg-deb-build.sh
+++ b/pkg/docker-engine/scripts/pkg-deb-build.sh
@@ -51,11 +51,7 @@ for l in $(gen-ver "${SRCDIR}"); do
 done
 
 xx-go --wrap
-
-# FIXME: CC is set to a cross package in Go release: https://github.com/docker/packaging/pull/25#issuecomment-1256594482
-if [ "$(go env CC)" = "$(xx-info triple)-gcc" ] && ! command "$(go env CC)" &> /dev/null; then
-  go env -w CC=gcc
-fi
+fix-cc
 
 cat > "debian/changelog" <<-EOF
 ${PKG_NAME} (${PKG_DEB_EPOCH}$([ -n "$PKG_DEB_EPOCH" ] && echo ":")${GENVER_PKG_VERSION}-${PKG_DEB_REVISION}) $PKG_SUITE; urgency=low

--- a/pkg/docker-engine/scripts/pkg-rpm-build.sh
+++ b/pkg/docker-engine/scripts/pkg-rpm-build.sh
@@ -50,11 +50,7 @@ for l in $(gen-ver "${SRCDIR}"); do
 done
 
 xx-go --wrap
-
-# FIXME: CC is set to a cross package in Go release: https://github.com/docker/packaging/pull/25#issuecomment-1256594482
-if [ "$(go env CC)" = "$(xx-info triple)-gcc" ] && ! command "$(go env CC)" &> /dev/null; then
-  go env -w CC=gcc
-fi
+fix-cc
 
 rpmDefine=(
   --define "_version ${GENVER_PKG_VERSION}"

--- a/pkg/docker-engine/scripts/pkg-static-build.sh
+++ b/pkg/docker-engine/scripts/pkg-static-build.sh
@@ -39,11 +39,7 @@ for l in $(gen-ver "${SRCDIR}"); do
 done
 
 xx-go --wrap
-
-# FIXME: Verify CC exists. Can be set to cross in official Go release: https://github.com/docker/packaging/pull/25#issuecomment-1256594482
-if ! which "$(go env CC)" &> /dev/null; then
-  go env -w CC=gcc
-fi
+fix-cc
 
 binext=$([ "$(xx-info os)" = "windows" ] && echo ".exe" || true)
 pkg=github.com/docker/docker

--- a/pkg/sbom/Dockerfile
+++ b/pkg/sbom/Dockerfile
@@ -101,6 +101,7 @@ ARG PKG_DEB_EPOCH
 ARG SOURCE_DATE_EPOCH
 RUN --mount=type=bind,source=scripts/pkg-deb-build.sh,target=/usr/local/bin/pkg-deb-build \
     --mount=type=bind,from=common-scripts,source=gen-ver.sh,target=/usr/local/bin/gen-ver \
+    --mount=type=bind,from=common-scripts,source=fix-cc.sh,target=/usr/local/bin/fix-cc \
     --mount=type=bind,from=src,source=/src,target=/root/package/sbom,rw \
     --mount=type=bind,from=go,source=/usr/local/go,target=/usr/local/go \
     OUTDIR=/out SRCDIR=./sbom pkg-deb-build
@@ -143,6 +144,7 @@ ARG PKG_RPM_RELEASE
 ARG SOURCE_DATE_EPOCH
 RUN --mount=type=bind,source=scripts/pkg-rpm-build.sh,target=/usr/local/bin/pkg-rpm-build \
     --mount=type=bind,from=common-scripts,source=gen-ver.sh,target=/usr/local/bin/gen-ver \
+    --mount=type=bind,from=common-scripts,source=fix-cc.sh,target=/usr/local/bin/fix-cc \
     --mount=type=bind,from=src-tgz,source=/out/sbom.tgz,target=/root/rpmbuild/SOURCES/sbom.tgz \
     --mount=type=bind,from=src,source=/src,target=/usr/local/src/sbom \
     --mount=type=bind,from=go,source=/usr/local/go,target=/usr/local/go \
@@ -164,6 +166,7 @@ WORKDIR /build
 ARG TARGETPLATFORM
 RUN --mount=type=bind,source=scripts/pkg-static-build.sh,target=/usr/local/bin/pkg-static-build \
     --mount=type=bind,from=common-scripts,source=gen-ver.sh,target=/usr/local/bin/gen-ver \
+    --mount=type=bind,from=common-scripts,source=fix-cc.sh,target=/usr/local/bin/fix-cc \
     --mount=type=bind,from=src,source=/src,target=/usr/local/src/sbom \
     --mount=type=bind,from=gocross,source=/usr/local/go,target=/usr/local/go,rw \
     OUTDIR=/out BUILDDIR=/build SRCDIR=/usr/local/src/sbom pkg-static-build

--- a/pkg/sbom/scripts/pkg-deb-build.sh
+++ b/pkg/sbom/scripts/pkg-deb-build.sh
@@ -51,11 +51,7 @@ for l in $(gen-ver "${SRCDIR}"); do
 done
 
 xx-go --wrap
-
-# FIXME: CC is set to a cross package in Go release: https://github.com/docker/packaging/pull/25#issuecomment-1256594482
-if [ "$(go env CC)" = "$(xx-info triple)-gcc" ] && ! command "$(go env CC)" &> /dev/null; then
-  go env -w CC=gcc
-fi
+fix-cc
 
 cat >"debian/changelog" <<-EOF
 ${PKG_NAME} (${PKG_DEB_EPOCH}$([ -n "$PKG_DEB_EPOCH" ] && echo ":")${GENVER_PKG_VERSION}-${PKG_DEB_REVISION}) $PKG_SUITE; urgency=low

--- a/pkg/sbom/scripts/pkg-rpm-build.sh
+++ b/pkg/sbom/scripts/pkg-rpm-build.sh
@@ -54,11 +54,7 @@ if [ -d "${SRCDIR}" ]; then
 fi
 
 xx-go --wrap
-
-# FIXME: CC is set to a cross package in Go release: https://github.com/docker/packaging/pull/25#issuecomment-1256594482
-if [ "$(go env CC)" = "$(xx-info triple)-gcc" ] && ! command "$(go env CC)" &> /dev/null; then
-  go env -w CC=gcc
-fi
+fix-cc
 
 rpmDefine=(
   --define "_version ${GENVER_PKG_VERSION}"

--- a/pkg/sbom/scripts/pkg-static-build.sh
+++ b/pkg/sbom/scripts/pkg-static-build.sh
@@ -39,11 +39,7 @@ for l in $(gen-ver "${SRCDIR}"); do
 done
 
 xx-go --wrap
-
-# FIXME: CC is set to a cross package in Go release: https://github.com/docker/packaging/pull/25#issuecomment-1256594482
-if [ "$(go env CC)" = "$(xx-info triple)-gcc" ] && ! command "$(go env CC)" &> /dev/null; then
-  go env -w CC=gcc
-fi
+fix-cc
 
 binext=$([ "$(xx-info os)" = "windows" ] && echo ".exe" || true)
 pkg=github.com/docker/sbom-cli-plugin

--- a/pkg/scan/Dockerfile
+++ b/pkg/scan/Dockerfile
@@ -101,6 +101,7 @@ ARG PKG_DEB_EPOCH
 ARG SOURCE_DATE_EPOCH
 RUN --mount=type=bind,source=scripts/pkg-deb-build.sh,target=/usr/local/bin/pkg-deb-build \
     --mount=type=bind,from=common-scripts,source=gen-ver.sh,target=/usr/local/bin/gen-ver \
+    --mount=type=bind,from=common-scripts,source=fix-cc.sh,target=/usr/local/bin/fix-cc \
     --mount=type=bind,from=src,source=/src,target=/root/package/scan,rw \
     --mount=type=bind,from=go,source=/usr/local/go,target=/usr/local/go \
     OUTDIR=/out SRCDIR=./scan pkg-deb-build
@@ -143,6 +144,7 @@ ARG PKG_RPM_RELEASE
 ARG SOURCE_DATE_EPOCH
 RUN --mount=type=bind,source=scripts/pkg-rpm-build.sh,target=/usr/local/bin/pkg-rpm-build \
     --mount=type=bind,from=common-scripts,source=gen-ver.sh,target=/usr/local/bin/gen-ver \
+    --mount=type=bind,from=common-scripts,source=fix-cc.sh,target=/usr/local/bin/fix-cc \
     --mount=type=bind,from=src-tgz,source=/out/scan.tgz,target=/root/rpmbuild/SOURCES/scan.tgz \
     --mount=type=bind,from=src,source=/src,target=/usr/local/src/scan \
     --mount=type=bind,from=go,source=/usr/local/go,target=/usr/local/go \
@@ -165,6 +167,7 @@ WORKDIR /build
 ARG TARGETPLATFORM
 RUN --mount=type=bind,source=scripts/pkg-static-build.sh,target=/usr/local/bin/pkg-static-build \
     --mount=type=bind,from=common-scripts,source=gen-ver.sh,target=/usr/local/bin/gen-ver \
+    --mount=type=bind,from=common-scripts,source=fix-cc.sh,target=/usr/local/bin/fix-cc \
     --mount=type=bind,from=src,source=/src,target=/usr/local/src/scan,rw \
     --mount=type=bind,from=gocross,source=/usr/local/go,target=/usr/local/go,rw \
     OUTDIR=/out BUILDDIR=/build SRCDIR=/usr/local/src/scan pkg-static-build

--- a/pkg/scan/scripts/pkg-deb-build.sh
+++ b/pkg/scan/scripts/pkg-deb-build.sh
@@ -51,11 +51,7 @@ for l in $(gen-ver "${SRCDIR}"); do
 done
 
 xx-go --wrap
-
-# FIXME: CC is set to a cross package in Go release: https://github.com/docker/packaging/pull/25#issuecomment-1256594482
-if [ "$(go env CC)" = "$(xx-info triple)-gcc" ] && ! command "$(go env CC)" &> /dev/null; then
-  go env -w CC=gcc
-fi
+fix-cc
 
 cat >"debian/changelog" <<-EOF
 ${PKG_NAME} (${PKG_DEB_EPOCH}$([ -n "$PKG_DEB_EPOCH" ] && echo ":")${GENVER_PKG_VERSION}-${PKG_DEB_REVISION}) $PKG_SUITE; urgency=low

--- a/pkg/scan/scripts/pkg-rpm-build.sh
+++ b/pkg/scan/scripts/pkg-rpm-build.sh
@@ -50,11 +50,7 @@ for l in $(gen-ver "${SRCDIR}"); do
 done
 
 xx-go --wrap
-
-# FIXME: CC is set to a cross package in Go release: https://github.com/docker/packaging/pull/25#issuecomment-1256594482
-if [ "$(go env CC)" = "$(xx-info triple)-gcc" ] && ! command "$(go env CC)" &> /dev/null; then
-  go env -w CC=gcc
-fi
+fix-cc
 
 rpmDefine=(
   --define "_version ${GENVER_PKG_VERSION}"

--- a/pkg/scan/scripts/pkg-static-build.sh
+++ b/pkg/scan/scripts/pkg-static-build.sh
@@ -39,11 +39,7 @@ for l in $(gen-ver "${SRCDIR}"); do
 done
 
 xx-go --wrap
-
-# FIXME: CC is set to a cross package in Go release: https://github.com/docker/packaging/pull/25#issuecomment-1256594482
-if [ "$(go env CC)" = "$(xx-info triple)-gcc" ] && ! command "$(go env CC)" &> /dev/null; then
-  go env -w CC=gcc
-fi
+fix-cc
 
 binext=$([ "$(xx-info os)" = "windows" ] && echo ".exe" || true)
 mkdir -p ${BUILDDIR}/${PKG_NAME}


### PR DESCRIPTION
Adds support for more platforms for docker-cli and docker-engine packages and also:
* Fixes an issue with `gen-ver` utility related to a dirty working tree for some projects
* Fixes static build for `dockerd` `docker-proxy` while waiting for https://github.com/moby/moby/pull/43529