### PR TITLE
ci(release): change nightly build tag format

### DIFF
--- a/.github/workflows/.release.yml
+++ b/.github/workflows/.release.yml
@@ -156,7 +156,7 @@ jobs:
           EOF
 
           if [ "${{ github.event_name }}" = "schedule" ]; then
-            echo "GIT_TAG=${{ inputs.name }}/nightly/$VERSION" >> $GITHUB_ENV
+            echo "GIT_TAG=nightly/${{ inputs.name }}/$VERSION" >> $GITHUB_ENV
           else
             echo "GIT_TAG=${{ inputs.name }}/$VERSION" >> $GITHUB_ENV
           fi

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ list of published Docker tags.
 > **Note**
 >
 > We are also publishing nightly builds using the
-> [`<project>/nightly/<version>` tags](https://hub.docker.com/r/dockereng/packaging/tags?page=1&name=%2Fnightly%2F).
+> [`nightly-<project>-<version>` tags](https://hub.docker.com/r/dockereng/packaging/tags?page=1&name=nightly-).
 
 ## Usage
 


### PR DESCRIPTION
new format: `nightly-<project>-<version>`

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>