### PR TITLE
common: remove software collections repo when Git installed

### DIFF
--- a/.github/workflows/.build.yml
+++ b/.github/workflows/.build.yml
@@ -25,6 +25,7 @@ jobs:
           - ubuntu2204
           - centos7
           - centos9
+          - oraclelinux7
           - fedora37
           - static
     steps:

--- a/common/scripts/rpm-init.sh
+++ b/common/scripts/rpm-init.sh
@@ -43,6 +43,9 @@ case "$pkgrelease" in
     #  https://wiki.centos.org/AdditionalResources/Repositories/SCL
     yum install -y centos-release-scl-rh
     swcolInstallGit "227"
+    # remove software collections repo when Git installed otherwise wrong deps
+    # are picked up by yum-builddep
+    yum remove -y centos-release-scl-rh
     ;;
   centos8)
     [ -f /etc/yum.repos.d/CentOS-Stream-Sources.repo ] && sed -i 's/altarch/centos/g' /etc/yum.repos.d/CentOS-Stream-Sources.repo
@@ -65,6 +68,9 @@ case "$pkgrelease" in
     yum install -y oracle-softwarecollection-release-el7
     yum-config-manager --enable ol7_software_collections
     swcolInstallGit "29"
+    # disable software collections repo when Git installed otherwise wrong deps
+    # are picked up by yum-builddep
+    yum-config-manager --disable ol7_software_collections
     ;;
   oraclelinux8)
     dnf install -y git rpm-build rpmlint dnf-plugins-core oraclelinux-release-el8 oracle-epel-release-el8

--- a/pkg/containerd/verify.Dockerfile
+++ b/pkg/containerd/verify.Dockerfile
@@ -48,8 +48,24 @@ EOT
 
 FROM ${PKG_BASE_IMAGE} AS verify-rpm
 COPY --from=xx / /
+ARG PKG_RELEASE
 ARG PKG_DISTRO
 ARG PKG_SUITE
+RUN <<EOT
+  set -e
+  # ol*_addons package required for container-selinux
+  case "$PKG_RELEASE" in
+    oraclelinux7)
+      yum-config-manager --enable ol7_addons
+      ;;
+    oraclelinux8)
+      dnf config-manager --enable ol8_addons
+      ;;
+    oraclelinux9)
+      dnf config-manager --enable ol9_addons
+      ;;
+  esac
+EOT
 ARG TARGETPLATFORM
 RUN --mount=from=bin-folder,target=/build <<EOT
   set -e

--- a/pkg/credential-helpers/verify.Dockerfile
+++ b/pkg/credential-helpers/verify.Dockerfile
@@ -52,8 +52,11 @@ ARG PKG_SUITE
 RUN <<EOT
   set -e
   case "$PKG_RELEASE" in
-    centos*|oraclelinux*)
+    centos*)
       yum install -y epel-release
+      ;;
+    oraclelinux*)
+      yum install -y oracle-epel-release-el7
       ;;
   esac
 EOT

--- a/pkg/docker-cli/verify.Dockerfile
+++ b/pkg/docker-cli/verify.Dockerfile
@@ -55,11 +55,14 @@ RUN --mount=from=bin-folder,target=/build <<EOT
     (
       set -x
       rpm -qilp $f
-      if [ "$PKG_RELEASE" = "centos7" ]; then
-        rpm --install --nodeps $f
-      else
-        yum install -y $f
-      fi
+      case "$PKG_RELEASE" in
+        centos7 | oraclelinux7)
+          rpm --install --nodeps $f
+          ;;
+        *)
+          yum install -y $f
+          ;;
+      esac
     )
   done
   set -x

--- a/pkg/docker-engine/verify.Dockerfile
+++ b/pkg/docker-engine/verify.Dockerfile
@@ -55,6 +55,18 @@ RUN <<EOT
       dnf install -y dnf-plugins-core
       dnf config-manager --set-enabled crb
       ;;
+    oraclelinux7)
+      yum install -y oraclelinux-release-el7 oracle-epel-release-el7
+      yum-config-manager --enable ol7_addons ol7_latest ol7_optional_latest
+      ;;
+    oraclelinux8)
+      dnf install -y dnf-plugins-core oraclelinux-release-el8 oracle-epel-release-el8
+      dnf config-manager --enable ol8_addons ol8_codeready_builder
+      ;;
+    oraclelinux9)
+      dnf install -y dnf-plugins-core oraclelinux-release-el9 oracle-epel-release-el9
+      dnf config-manager --enable ol9_addons ol9_codeready_builder
+      ;;
   esac
   yum install -y device-mapper-devel
 EOT


### PR DESCRIPTION
Encounter this issue with containerd package:

```
#64 4.382 ================================================================================
#64 4.382  Package              Arch   Version             Repository                Size
#64 4.382 ================================================================================
#64 4.382 Installing:
#64 4.382  btrfs-progs-devel    x86_64 4.9.1-1.0.2.el7     ol7_optional_latest       46 k
#64 4.382  devtoolset-4-gcc     x86_64 5.3.1-6.1.el7       ol7_software_collections  26 M
#64 4.382  libseccomp-devel     x86_64 2.3.1-4.el7         ol7_optional_latest       63 k
#64 4.382  libtool-ltdl-devel   x86_64 2.4.2-22.el7_3      ol7_latest               167 k
#64 4.382  make                 x86_64 1:3.82-24.el7       ol7_latest               420 k
#64 4.382 Installing for dependencies:
#64 4.382  btrfs-progs          x86_64 4.9.1-1.0.2.el7     ol7_latest               678 k
#64 4.382  devtoolset-4-runtime x86_64 4.1-3.0.1.el7       ol7_software_collections  26 k
#64 4.382  e2fsprogs-libs       x86_64 1.42.9-19.0.1.el7   ol7_latest               168 k
#64 4.382  glibc-devel          x86_64 2.17-326.0.1.el7_9  ol7_latest               1.1 M
#64 4.382  glibc-headers        x86_64 2.17-326.0.1.el7_9  ol7_latest               694 k
#64 4.382  kernel-headers       x86_64 3.10.0-1160.76.1.0.1.el7
#64 4.382                                                  ol7_latest               9.1 M
#64 4.382  libgomp              x86_64 4.8.5-44.0.3.el7    ol7_latest               159 k
#64 4.382  libmpc               x86_64 1.0.1-3.el7         ol7_latest                49 k
#64 4.382  libseccomp           x86_64 2.3.1-4.el7         ol7_latest                56 k
#64 4.382  libtool-ltdl         x86_64 2.4.2-22.el7_3      ol7_latest                48 k
#64 4.382  lzo                  x86_64 2.06-8.el7          ol7_latest                58 k
#64 4.382  mpfr                 x86_64 3.1.1-4.el7         ol7_latest               198 k
...
...
...
#66 39.83 # command-line-arguments
#66 39.83 /usr/local/go/pkg/tool/linux_amd64/link: running gcc failed: exec: "gcc": executable file not found in $PATH
#66 39.83 
#66 39.90 make: *** [man/ctr.8] Error 2
#66 39.90 error: Bad exit status from /var/tmp/rpm-tmp.JecA2T (%build)
#66 39.90 
#66 39.90 
#66 39.90 RPM build errors:
#66 39.90     Bad exit status from /var/tmp/rpm-tmp.JecA2T (%build)
```

Seems Software Collections repo overrides `gcc` package with `devtoolset-4-gcc` :neutral_face:. Remove repo right after Git is installed from SW Collections repo so we make sure the right deps are installed for our packages.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>