### PR TITLE
pkg(docker-engine): BINARY_SHORT_NAME deprecated

### DIFF
--- a/pkg/docker-engine/scripts/pkg-static-build.sh
+++ b/pkg/docker-engine/scripts/pkg-static-build.sh
@@ -65,9 +65,11 @@ esac
 if [ "$(xx-info os)" = "windows" ]; then
   (
     pushd ${SRCDIR}
-      BINARY_SHORT_NAME="dockerd" BINARY_FULLNAME="dockerd.exe" VERSION="${GENVER_VERSION}" GITCOMMIT="${GENVER_COMMIT}" . hack/make/.mkwinres
+      # FIXME: BINARY_SHORT_NAME deprecated, remove when 22.06 branch rebased with master
+      BINARY_NAME="dockerd" BINARY_SHORT_NAME="dockerd" BINARY_FULLNAME="dockerd.exe" VERSION="${GENVER_VERSION}" GITCOMMIT="${GENVER_COMMIT}" . hack/make/.mkwinres
       go generate -v "./cmd/dockerd"
-      BINARY_SHORT_NAME="docker-proxy" BINARY_FULLNAME="docker-proxy.exe" VERSION="${GENVER_VERSION}" GITCOMMIT="${GENVER_COMMIT}" . hack/make/.mkwinres
+      # FIXME: BINARY_SHORT_NAME deprecated, remove when 22.06 branch rebased with master
+      BINARY_NAME="docker-proxy" BINARY_SHORT_NAME="docker-proxy" BINARY_FULLNAME="docker-proxy.exe" VERSION="${GENVER_VERSION}" GITCOMMIT="${GENVER_COMMIT}" . hack/make/.mkwinres
       go generate -v "./cmd/docker-proxy"
     popd
   )


### PR DESCRIPTION
related to https://github.com/moby/moby/pull/43762

last nightly build failed with: https://github.com/docker/packaging/actions/runs/3213097052/jobs/5276739551#step:7:2616

```
#0 0.995 cmd/dockerd/config.go
#0 0.996 cmd/dockerd/config_windows.go
#0 0.997 cmd/dockerd/daemon.go
#0 0.997 cmd/dockerd/daemon_test.go
#0 0.997 cmd/dockerd/daemon_windows.go
#0 0.998 cmd/dockerd/docker.go
#0 0.998 cmd/dockerd/docker_windows.go
#0 0.998 cmd/dockerd/genwinres_windows.go
#0 1.001 2022/10/11 07:42:18 open ../../cli/winresources/dockerd/winres.json: no such file or directory
#0 1.007 cmd/dockerd/genwinres_windows.go:1: running "go-winres": exit status 1
```

@thaJeztah Could you backport https://github.com/moby/moby/pull/43762 to 22.06 maybe?

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>