### PR TITLE
pkg(containerd): update to 1.6.15

### DIFF
--- a/pkg/containerd/Dockerfile
+++ b/pkg/containerd/Dockerfile
@@ -17,7 +17,7 @@
 ARG XX_VERSION="1.1.2"
 ARG DEBIAN_FRONTEND="noninteractive"
 
-# https://github.com/containerd/containerd/blob/v1.6.14/.github/workflows/ci.yml#L125
+# https://github.com/containerd/containerd/blob/v1.6.15/.github/workflows/ci.yml#L125
 ARG MD2MAN_VERSION="v2.0.1"
 
 # common args

--- a/pkg/containerd/Makefile
+++ b/pkg/containerd/Makefile
@@ -14,21 +14,21 @@
 
 include ../../common/vars.mk
 
-# https://github.com/containerd/containerd/blob/v1.6.14/.github/workflows/release.yml#L9
+# https://github.com/containerd/containerd/blob/v1.6.15/.github/workflows/release.yml#L9
 export GO_VERSION = 1.18.9
 
 DESTDIR ?= $(BASEDIR)/bin
 BAKE_DEFINITIONS ?= -f docker-bake.hcl -f ../../common/packages.hcl
 
 export CONTAINERD_REPO := $(if $(CONTAINERD_REPO),$(CONTAINERD_REPO),https://github.com/containerd/containerd.git)
-export CONTAINERD_REF := $(if $(CONTAINERD_REF),$(CONTAINERD_REF),v1.6.14)
+export CONTAINERD_REF := $(if $(CONTAINERD_REF),$(CONTAINERD_REF),v1.6.15)
 export RUNC_REPO := $(if $(RUNC_REPO),$(RUNC_REPO),https://github.com/opencontainers/runc.git)
 export RUNC_REF := $(if $(RUNC_REF),$(RUNC_REF),)
 
 export PKG_DEB_REVISION = 1
 
 PKG_LIST ?= deb rpm static
-# supported platforms: https://github.com/containerd/containerd/blob/v1.6.14/.github/workflows/ci.yml#L138-L156
+# supported platforms: https://github.com/containerd/containerd/blob/v1.6.15/.github/workflows/ci.yml#L138-L156
 # FIXME: can't build static binaries with containerd Makefile for darwin/amd64 darwin/arm64 windows/amd64 platforms
 # FIXME: linux/riscv64 needs ubuntu:22.04 image
 # FIXME: add linux/ppc64le when a remote PowerPC instance is available (too slow with QEMU)

--- a/pkg/containerd/deb/changelog
+++ b/pkg/containerd/deb/changelog
@@ -1,3 +1,9 @@
+containerd.io (1.6.15-1) release; urgency=medium
+
+   * Update containerd to v1.6.15
+
+  -- Sebastiaan van Stijn <thajeztah@docker.com>  Mon, 09 Jan 2023 12:17:39 +0000
+
 containerd.io (1.6.14-1) release; urgency=medium
 
   * Update containerd to v1.6.14

--- a/pkg/containerd/docker-bake.hcl
+++ b/pkg/containerd/docker-bake.hcl
@@ -21,7 +21,7 @@ variable "CONTAINERD_REPO" {
 
 # Sets the containerd ref.
 variable "CONTAINERD_REF" {
-  default = "v1.6.14"
+  default = "v1.6.15"
 }
 
 # In case we want to set runc to a specific version instead of using

--- a/pkg/containerd/rpm/containerd.spec
+++ b/pkg/containerd/rpm/containerd.spec
@@ -163,6 +163,9 @@ done
 
 
 %changelog
+* Mon Jan 09 2023 Sebastiaan van Stijn <thajeztah@docker.com> - 1.6.15-3.1
+ - Update containerd to v1.6.15
+
 * Mon Dec 19 2022 Sebastiaan van Stijn <thajeztah@docker.com> - 1.6.14-3.1
 - Update containerd to v1.6.14
 


### PR DESCRIPTION
- relates to https://github.com/docker/containerd-packaging/pull/304


release notes: https://github.com/containerd/containerd/releases/tag/v1.6.15

> Welcome to the v1.6.15 release of containerd!
>
> The fifteenth patch release for containerd 1.6 fixes an issue with CNI in the CRI plugin
>
> Notable Updates
>
> - Fix no CNI info for pod sandbox on restart in CRI plugin

full diff: https://github.com/containerd/containerd/compare/v1.6.14...v1.6.15
