### PR TITLE
pkg: use default branch

### DIFF
--- a/.github/workflows/release-buildx.yml
+++ b/.github/workflows/release-buildx.yml
@@ -9,12 +9,12 @@ on:
     - cron: '0 1 * * 0' # every sunday at 1am
   workflow_dispatch:
     inputs:
-      repo:
-        description: 'Override repo'
-        required: false
-        type: string
       ref:
-        description: 'Override ref'
+        description: 'Ref (e.g. v0.10.0)'
+        required: true
+        type: string
+      repo:
+        description: 'Override default repo'
         required: false
         type: string
       release:
@@ -41,5 +41,4 @@ jobs:
       name: buildx
       env: |
         NIGHTLY_BUILD=1
-        BUILDX_REF=master
     secrets: inherit

--- a/.github/workflows/release-compose.yml
+++ b/.github/workflows/release-compose.yml
@@ -9,12 +9,12 @@ on:
     - cron: '0 2 * * 0' # every sunday at 2am
   workflow_dispatch:
     inputs:
-      repo:
-        description: 'Override repo'
-        required: false
-        type: string
       ref:
-        description: 'Override ref'
+        description: 'Ref (e.g. v2.15.1)'
+        required: true
+        type: string
+      repo:
+        description: 'Override default repo'
         required: false
         type: string
       release:
@@ -41,5 +41,4 @@ jobs:
       name: compose
       env: |
         NIGHTLY_BUILD=1
-        COMPOSE_REF=v2
     secrets: inherit

--- a/.github/workflows/release-containerd.yml
+++ b/.github/workflows/release-containerd.yml
@@ -9,12 +9,12 @@ on:
     - cron: '0 3 * * 0' # every sunday at 3am
   workflow_dispatch:
     inputs:
-      repo:
-        description: 'Override repo'
-        required: false
-        type: string
       ref:
-        description: 'Override ref'
+        description: 'Ref (e.g. v1.6.15)'
+        required: true
+        type: string
+      repo:
+        description: 'Override default repo'
         required: false
         type: string
       runc_repo:
@@ -51,5 +51,4 @@ jobs:
       name: containerd
       env: |
         NIGHTLY_BUILD=1
-        CONTAINERD_REF=main
     secrets: inherit

--- a/.github/workflows/release-credential-helpers.yml
+++ b/.github/workflows/release-credential-helpers.yml
@@ -9,12 +9,12 @@ on:
     - cron: '0 4 * * 0' # every sunday at 4am
   workflow_dispatch:
     inputs:
-      repo:
-        description: 'Override repo'
-        required: false
-        type: string
       ref:
-        description: 'Override ref'
+        description: 'Ref (e.g. v1.7.0)'
+        required: true
+        type: string
+      repo:
+        description: 'Override default repo'
         required: false
         type: string
       release:
@@ -41,5 +41,4 @@ jobs:
       name: credential-helpers
       env: |
         NIGHTLY_BUILD=1
-        CREDENTIAL_HELPERS_REF=master
     secrets: inherit

--- a/.github/workflows/release-docker-cli.yml
+++ b/.github/workflows/release-docker-cli.yml
@@ -9,12 +9,12 @@ on:
     - cron: '0 5 * * 0' # every sunday at 5am
   workflow_dispatch:
     inputs:
-      repo:
-        description: 'Override repo'
-        required: false
-        type: string
       ref:
-        description: 'Override ref'
+        description: 'Ref (e.g. v23.0.0)'
+        required: true
+        type: string
+      repo:
+        description: 'Override default repo'
         required: false
         type: string
       release:
@@ -41,5 +41,4 @@ jobs:
       name: docker-cli
       env: |
         NIGHTLY_BUILD=1
-        DOCKER_CLI_REF=master
     secrets: inherit

--- a/.github/workflows/release-docker-engine.yml
+++ b/.github/workflows/release-docker-engine.yml
@@ -9,12 +9,12 @@ on:
     - cron: '0 6 * * 0' # every sunday at 6am
   workflow_dispatch:
     inputs:
-      repo:
-        description: 'Override repo'
-        required: false
-        type: string
       ref:
-        description: 'Override ref'
+        description: 'Ref (e.g. v23.0.0)'
+        required: true
+        type: string
+      repo:
+        description: 'Override default repo'
         required: false
         type: string
       release:
@@ -41,5 +41,4 @@ jobs:
       name: docker-engine
       env: |
         NIGHTLY_BUILD=1
-        DOCKER_ENGINE_REF=master
     secrets: inherit

--- a/.github/workflows/release-sbom.yml
+++ b/.github/workflows/release-sbom.yml
@@ -9,12 +9,12 @@ on:
     - cron: '0 7 * * 0' # every sunday at 7am
   workflow_dispatch:
     inputs:
-      repo:
-        description: 'Override repo'
-        required: false
-        type: string
       ref:
-        description: 'Override ref'
+        description: 'Ref (e.g. v0.6.1)'
+        required: true
+        type: string
+      repo:
+        description: 'Override default repo'
         required: false
         type: string
       release:
@@ -41,5 +41,4 @@ jobs:
       name: sbom
       env: |
         NIGHTLY_BUILD=1
-        SBOM_REF=main
     secrets: inherit

--- a/.github/workflows/release-scan.yml
+++ b/.github/workflows/release-scan.yml
@@ -9,12 +9,12 @@ on:
     - cron: '0 8 * * 0' # every sunday at 8am
   workflow_dispatch:
     inputs:
-      repo:
-        description: 'Override repo'
-        required: false
-        type: string
       ref:
-        description: 'Override ref'
+        description: 'Ref (e.g. v0.23.0)'
+        required: true
+        type: string
+      repo:
+        description: 'Override default repo'
         required: false
         type: string
       release:
@@ -41,5 +41,4 @@ jobs:
       name: scan
       env: |
         NIGHTLY_BUILD=1
-        SCAN_REF=main
     secrets: inherit

--- a/pkg/buildx/Makefile
+++ b/pkg/buildx/Makefile
@@ -14,17 +14,17 @@
 
 include ../../common/vars.mk
 
-# https://github.com/docker/buildx/blob/eab3f704f53577310c2d05700ab663f8a7ad4c8e/Dockerfile#L3
+# https://github.com/docker/buildx/blob/master/Dockerfile#L3
 export GO_VERSION = 1.19
 
 DESTDIR ?= $(BASEDIR)/bin
 BAKE_DEFINITIONS ?= -f docker-bake.hcl -f ../../common/packages.hcl
 
 export BUILDX_REPO := $(if $(BUILDX_REPO),$(BUILDX_REPO),https://github.com/docker/buildx.git)
-export BUILDX_REF := $(if $(BUILDX_REF),$(BUILDX_REF),v0.10.0)
+export BUILDX_REF := $(if $(BUILDX_REF),$(BUILDX_REF),master)
 
 PKG_LIST ?= deb rpm static
-# supported platforms: https://github.com/docker/buildx/blob/e98c2524905e659d34ac01cc328cd21c966be3f2/docker-bake.hcl#L112-L124
+# supported platforms: https://github.com/docker/buildx/blob/master/docker-bake.hcl#L110-L122
 # FIXME: add linux/ppc64le when a remote PowerPC instance is available (too slow with QEMU)
 PKG_PLATFORMS ?= darwin/amd64 darwin/arm64 linux/amd64 linux/arm/v6 linux/arm/v7 linux/arm64 linux/riscv64 linux/s390x windows/amd64 windows/arm64
 

--- a/pkg/buildx/docker-bake.hcl
+++ b/pkg/buildx/docker-bake.hcl
@@ -21,7 +21,7 @@ variable "BUILDX_REPO" {
 
 # Sets the buildx ref.
 variable "BUILDX_REF" {
-  default = "v0.10.0"
+  default = "master"
 }
 
 # set to 1 to enforce nightly build

--- a/pkg/compose/Dockerfile
+++ b/pkg/compose/Dockerfile
@@ -19,7 +19,7 @@ ARG DEBIAN_FRONTEND="noninteractive"
 
 # common args
 ARG GO_IMAGE="golang"
-ARG GO_VERSION="1.18.5"
+ARG GO_VERSION="1.19.4"
 ARG GO_IMAGE_VARIANT="bullseye"
 ARG PKG_RELEASE="debian11"
 ARG PKG_TYPE="deb"

--- a/pkg/compose/Makefile
+++ b/pkg/compose/Makefile
@@ -14,17 +14,17 @@
 
 include ../../common/vars.mk
 
-# https://github.com/docker/compose/blob/v2.15.1/Dockerfile#L18
+# https://github.com/docker/compose/blob/v2/Dockerfile#L18
 export GO_VERSION = 1.19.4
 
 DESTDIR ?= $(BASEDIR)/bin
 BAKE_DEFINITIONS ?= -f docker-bake.hcl -f ../../common/packages.hcl
 
 export COMPOSE_REPO := $(if $(COMPOSE_REPO),$(COMPOSE_REPO),https://github.com/docker/compose.git)
-export COMPOSE_REF := $(if $(COMPOSE_REF),$(COMPOSE_REF),v2.15.1)
+export COMPOSE_REF := $(if $(COMPOSE_REF),$(COMPOSE_REF),v2)
 
 PKG_LIST ?= deb rpm static
-# supported platforms: https://github.com/docker/compose/blob/e2a3fe94273b05a1428652ba248edeee4171427f/docker-bake.hcl#L95-L107
+# supported platforms: https://github.com/docker/compose/blob/v2/docker-bake.hcl#L95-L107
 # FIXME: add linux/ppc64le when a remote PowerPC instance is available (too slow with QEMU)
 PKG_PLATFORMS ?= darwin/amd64 darwin/arm64 linux/amd64 linux/arm/v6 linux/arm/v7 linux/arm64 linux/riscv64 linux/s390x windows/amd64 windows/arm64
 

--- a/pkg/compose/docker-bake.hcl
+++ b/pkg/compose/docker-bake.hcl
@@ -21,7 +21,7 @@ variable "COMPOSE_REPO" {
 
 # Sets the compose ref.
 variable "COMPOSE_REF" {
-  default = "v2.15.1"
+  default = "v2"
 }
 
 # set to 1 to enforce nightly build

--- a/pkg/containerd/Dockerfile
+++ b/pkg/containerd/Dockerfile
@@ -17,12 +17,12 @@
 ARG XX_VERSION="1.1.2"
 ARG DEBIAN_FRONTEND="noninteractive"
 
-# https://github.com/containerd/containerd/blob/v1.6.15/.github/workflows/ci.yml#L125
-ARG MD2MAN_VERSION="v2.0.1"
+# https://github.com/containerd/containerd/blob/main/.github/workflows/ci.yml#L132
+ARG MD2MAN_VERSION="v2.0.2"
 
 # common args
 ARG GO_IMAGE="golang"
-ARG GO_VERSION="1.18.9"
+ARG GO_VERSION="1.19.4"
 ARG GO_IMAGE_VARIANT="bullseye"
 ARG PKG_RELEASE="debian11"
 ARG PKG_TYPE="deb"

--- a/pkg/containerd/Makefile
+++ b/pkg/containerd/Makefile
@@ -14,21 +14,21 @@
 
 include ../../common/vars.mk
 
-# https://github.com/containerd/containerd/blob/v1.6.15/.github/workflows/release.yml#L9
-export GO_VERSION = 1.18.9
+# https://github.com/containerd/containerd/blob/main/.github/workflows/release.yml#L9
+export GO_VERSION = 1.19.4
 
 DESTDIR ?= $(BASEDIR)/bin
 BAKE_DEFINITIONS ?= -f docker-bake.hcl -f ../../common/packages.hcl
 
 export CONTAINERD_REPO := $(if $(CONTAINERD_REPO),$(CONTAINERD_REPO),https://github.com/containerd/containerd.git)
-export CONTAINERD_REF := $(if $(CONTAINERD_REF),$(CONTAINERD_REF),v1.6.15)
+export CONTAINERD_REF := $(if $(CONTAINERD_REF),$(CONTAINERD_REF),main)
 export RUNC_REPO := $(if $(RUNC_REPO),$(RUNC_REPO),https://github.com/opencontainers/runc.git)
 export RUNC_REF := $(if $(RUNC_REF),$(RUNC_REF),)
 
 export PKG_DEB_REVISION = 1
 
 PKG_LIST ?= deb rpm static
-# supported platforms: https://github.com/containerd/containerd/blob/v1.6.15/.github/workflows/ci.yml#L138-L156
+# supported platforms: https://github.com/containerd/containerd/blob/main/.github/workflows/ci.yml#L145-L165
 # FIXME: can't build static binaries with containerd Makefile for darwin/amd64 darwin/arm64 windows/amd64 platforms
 # FIXME: linux/riscv64 needs ubuntu:22.04 image
 # FIXME: add linux/ppc64le when a remote PowerPC instance is available (too slow with QEMU)

--- a/pkg/containerd/docker-bake.hcl
+++ b/pkg/containerd/docker-bake.hcl
@@ -21,7 +21,7 @@ variable "CONTAINERD_REPO" {
 
 # Sets the containerd ref.
 variable "CONTAINERD_REF" {
-  default = "v1.6.15"
+  default = "main"
 }
 
 # In case we want to set runc to a specific version instead of using
@@ -43,7 +43,7 @@ variable "GO_IMAGE" {
   default = "golang"
 }
 variable "GO_VERSION" {
-  default = "1.18.9"
+  default = "1.19.4"
 }
 variable "GO_IMAGE_VARIANT" {
   default = "bullseye"

--- a/pkg/credential-helpers/Makefile
+++ b/pkg/credential-helpers/Makefile
@@ -14,17 +14,17 @@
 
 include ../../common/vars.mk
 
-# https://github.com/docker/docker-credential-helpers/blob/ac5992b5f4756fc0398a7d0c93c609e624368bde/Dockerfile#L3
+# https://github.com/docker/docker-credential-helpers/blob/master/Dockerfile#L3
 export GO_VERSION = 1.18.5
 
 DESTDIR ?= $(BASEDIR)/bin
 BAKE_DEFINITIONS ?= -f docker-bake.hcl -f ../../common/packages.hcl
 
 export CREDENTIAL_HELPERS_REPO := $(if $(CREDENTIAL_HELPERS_REPO),$(CREDENTIAL_HELPERS_REPO),https://github.com/docker/docker-credential-helpers.git)
-export CREDENTIAL_HELPERS_REF := $(if $(CREDENTIAL_HELPERS_REF),$(CREDENTIAL_HELPERS_REF),v0.7.0)
+export CREDENTIAL_HELPERS_REF := $(if $(CREDENTIAL_HELPERS_REF),$(CREDENTIAL_HELPERS_REF),master)
 
 PKG_LIST ?= deb rpm static
-# supported platforms: https://github.com/docker/docker-credential-helpers/blob/ac5992b5f4756fc0398a7d0c93c609e624368bde/docker-bake.hcl#L56-L66
+# supported platforms: https://github.com/docker/docker-credential-helpers/blob/master/docker-bake.hcl#L56-L66
 # FIXME: add linux/ppc64le when a remote PowerPC instance is available (too slow with QEMU)
 PKG_PLATFORMS ?= darwin/amd64 darwin/arm64 linux/amd64 linux/arm/v6 linux/arm/v7 linux/arm64 linux/s390x windows/amd64
 

--- a/pkg/credential-helpers/docker-bake.hcl
+++ b/pkg/credential-helpers/docker-bake.hcl
@@ -21,7 +21,7 @@ variable "CREDENTIAL_HELPERS_REPO" {
 
 # Sets the credential helpers ref.
 variable "CREDENTIAL_HELPERS_REF" {
-  default = "v0.7.0"
+  default = "master"
 }
 
 # set to 1 to enforce nightly build

--- a/pkg/docker-cli/Dockerfile
+++ b/pkg/docker-cli/Dockerfile
@@ -17,7 +17,7 @@
 ARG XX_VERSION="1.1.2"
 ARG DEBIAN_FRONTEND="noninteractive"
 
-# https://github.com/docker/cli/blob/v23.0.0-rc.1/Dockerfile#L7
+# https://github.com/docker/cli/blob/master/Dockerfile#L7
 ARG GOVERSIONINFO_VERSION="v1.3.0"
 
 # common args

--- a/pkg/docker-cli/Makefile
+++ b/pkg/docker-cli/Makefile
@@ -14,20 +14,20 @@
 
 include ../../common/vars.mk
 
-# https://github.com/docker/cli/blob/v23.0.0-rc.1/Dockerfile#L4
+# https://github.com/docker/cli/blob/master/Dockerfile#L4
 export GO_VERSION = 1.19.4
 
 DESTDIR ?= $(BASEDIR)/bin
 BAKE_DEFINITIONS ?= -f docker-bake.hcl -f ../../common/packages.hcl
 
 export DOCKER_CLI_REPO := $(if $(DOCKER_CLI_REPO),$(DOCKER_CLI_REPO),https://github.com/docker/cli.git)
-export DOCKER_CLI_REF := $(if $(DOCKER_CLI_REF),$(DOCKER_CLI_REF),v23.0.0-rc.1)
+export DOCKER_CLI_REF := $(if $(DOCKER_CLI_REF),$(DOCKER_CLI_REF),master)
 
 export PKG_DEB_REVISION = 3
 export PKG_RPM_RELEASE = 3
 
 PKG_LIST ?= deb rpm static
-# supported platforms: https://github.com/docker/cli/blob/3e9117b7e241439e314eaf6fe944b4019fbaa941/docker-bake.hcl#L65-L67
+# supported platforms: https://github.com/docker/cli/blob/master/docker-bake.hcl#L30-L42
 # FIXME: add linux/ppc64le when a remote PowerPC instance is available (too slow with QEMU)
 PKG_PLATFORMS ?= darwin/amd64 darwin/arm64 linux/386 linux/amd64 linux/arm/v6 linux/arm/v7 linux/arm64 linux/riscv64 linux/s390x windows/amd64 windows/arm64
 

--- a/pkg/docker-cli/docker-bake.hcl
+++ b/pkg/docker-cli/docker-bake.hcl
@@ -21,7 +21,7 @@ variable "DOCKER_CLI_REPO" {
 
 # Sets the docker cli ref.
 variable "DOCKER_CLI_REF" {
-  default = "v23.0.0-rc.1"
+  default = "master"
 }
 
 # set to 1 to enforce nightly build

--- a/pkg/docker-engine/Dockerfile
+++ b/pkg/docker-engine/Dockerfile
@@ -17,7 +17,7 @@
 ARG XX_VERSION="1.1.2"
 ARG DEBIAN_FRONTEND="noninteractive"
 
-# https://github.com/moby/moby/blob/v23.0.0-rc.1/Dockerfile#L233
+# https://github.com/moby/moby/blob/master/Dockerfile#L178
 ARG GOWINRES_VERSION="v0.3.0"
 
 # common args

--- a/pkg/docker-engine/Makefile
+++ b/pkg/docker-engine/Makefile
@@ -14,22 +14,22 @@
 
 include ../../common/vars.mk
 
-# https://github.com/moby/moby/blob/v23.0.0-rc.1/Dockerfile#L3
+# https://github.com/moby/moby/blob/master/Dockerfile#L3
 export GO_VERSION = 1.19.4
 
 DESTDIR ?= $(BASEDIR)/bin
 BAKE_DEFINITIONS ?= -f docker-bake.hcl -f ../../common/packages.hcl
 
 export DOCKER_ENGINE_REPO := $(if $(DOCKER_ENGINE_REPO),$(DOCKER_ENGINE_REPO),https://github.com/docker/docker.git)
-export DOCKER_ENGINE_REF := $(if $(DOCKER_ENGINE_REF),$(DOCKER_ENGINE_REF),v23.0.0-rc.1)
+export DOCKER_ENGINE_REF := $(if $(DOCKER_ENGINE_REF),$(DOCKER_ENGINE_REF),master)
 
 export PKG_DEB_REVISION = 3
 export PKG_RPM_RELEASE = 3
 
 PKG_LIST ?= deb rpm static
-# supported platforms: https://github.com/moby/moby/blob/0e873d5cd8b31c08e29ff2f790c19a2e9c4ee30a/.github/workflows/ci.yml#L65-L73
+# supported platforms: https://github.com/moby/moby/blob/master/docker-bake.hcl#L93-L101
 # FIXME: add linux/ppc64le when a remote PowerPC instance is available (too slow with QEMU)
-PKG_PLATFORMS ?= linux/amd64 linux/arm/v6 linux/arm/v7 linux/arm64 linux/s390x windows/amd64 windows/arm64
+PKG_PLATFORMS ?= linux/amd64 linux/arm/v6 linux/arm/v7 linux/arm64 linux/s390x windows/amd64
 
 .PHONY: default
 default: pkg ;

--- a/pkg/docker-engine/docker-bake.hcl
+++ b/pkg/docker-engine/docker-bake.hcl
@@ -21,7 +21,7 @@ variable "DOCKER_ENGINE_REPO" {
 
 # Sets the docker engine ref.
 variable "DOCKER_ENGINE_REF" {
-  default = "v23.0.0-rc.1"
+  default = "master"
 }
 
 # set to 1 to enforce nightly build

--- a/pkg/docker-engine/scripts/pkg-rpm-build.sh
+++ b/pkg/docker-engine/scripts/pkg-rpm-build.sh
@@ -67,7 +67,7 @@ if [ -n "$(xx-info variant)" ]; then
 fi
 
 case "$PKG_RELEASE" in
-  centos8|centos9|oraclelinux*)
+  centos7|centos8|centos9|oraclelinux*)
     rpmDefine+=(--define "_without_btrfs 1")
     export DOCKER_BUILDTAGS="exclude_graphdriver_btrfs $DOCKER_BUILDTAGS"
     ;;

--- a/pkg/sbom/Makefile
+++ b/pkg/sbom/Makefile
@@ -14,17 +14,17 @@
 
 include ../../common/vars.mk
 
-# https://github.com/docker/sbom-cli-plugin/blob/b17d47dc0b20061e7924e835716caef3c6cc6a46/.github/workflows/release.yaml#L12
+# https://github.com/docker/sbom-cli-plugin/blob/main/.github/workflows/release.yaml#L12
 export GO_VERSION = 1.18
 
 DESTDIR ?= $(BASEDIR)/bin
 BAKE_DEFINITIONS ?= -f docker-bake.hcl -f ../../common/packages.hcl
 
 export SBOM_REPO := $(if $(SBOM_REPO),$(SBOM_REPO),https://github.com/docker/sbom-cli-plugin.git)
-export SBOM_REF := $(if $(SBOM_REF),$(SBOM_REF),v0.6.1)
+export SBOM_REF := $(if $(SBOM_REF),$(SBOM_REF),main)
 
 PKG_LIST ?= deb rpm static
-# supported platforms: https://github.com/docker/sbom-cli-plugin/blob/b17d47dc0b20061e7924e835716caef3c6cc6a46/.goreleaser.yaml#L7-L13
+# supported platforms: https://github.com/docker/sbom-cli-plugin/blob/main/.goreleaser.yaml#L7-L13
 PKG_PLATFORMS ?= darwin/amd64 darwin/arm64 linux/amd64 linux/arm64 windows/amd64 windows/arm64
 
 .PHONY: default

--- a/pkg/sbom/docker-bake.hcl
+++ b/pkg/sbom/docker-bake.hcl
@@ -21,7 +21,7 @@ variable "SBOM_REPO" {
 
 # Sets the sbom ref.
 variable "SBOM_REF" {
-  default = "v0.6.1"
+  default = "main"
 }
 
 # set to 1 to enforce nightly build

--- a/pkg/scan/Makefile
+++ b/pkg/scan/Makefile
@@ -14,17 +14,17 @@
 
 include ../../common/vars.mk
 
-# https://github.com/docker/scan-cli-plugin/blob/19992b1a37d4c419d70a92f3b37eabb0cbec7a11/Dockerfile#L19
+# https://github.com/docker/scan-cli-plugin/blob/main/Dockerfile#L19
 export GO_VERSION = 1.17.2
 
 DESTDIR ?= $(BASEDIR)/bin
 BAKE_DEFINITIONS ?= -f docker-bake.hcl -f ../../common/packages.hcl
 
 export SCAN_REPO := $(if $(SCAN_REPO),$(SCAN_REPO),https://github.com/docker/scan-cli-plugin.git)
-export SCAN_REF := $(if $(SCAN_REF),$(SCAN_REF),v0.23.0)
+export SCAN_REF := $(if $(SCAN_REF),$(SCAN_REF),main)
 
 PKG_LIST ?= deb rpm static
-# supported platforms: https://github.com/docker/scan-cli-plugin/blob/9c797021449e3192a46ba86730d6f0e5409b6614/builder.Makefile#L62-L67
+# supported platforms: https://github.com/docker/scan-cli-plugin/blob/main/builder.Makefile#L63-L67
 PKG_PLATFORMS ?= darwin/amd64 darwin/arm64 linux/amd64 linux/arm64 windows/amd64
 
 .PHONY: default

--- a/pkg/scan/docker-bake.hcl
+++ b/pkg/scan/docker-bake.hcl
@@ -21,7 +21,7 @@ variable "SCAN_REPO" {
 
 # Sets the scan ref.
 variable "SCAN_REF" {
-  default = "v0.23.0"
+  default = "main"
 }
 
 # set to 1 to enforce nightly build


### PR DESCRIPTION
Use default branch when building packages and requires a ref (version) to be set when creating a release.