### PR TITLE
ci: created dedicated nightly workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,71 @@
+# This workflow runs nighly builds for each package. Jobs don't run concurrently
+# to avoid performance issues on remote builders and also having a huge queue
+# in the pipeline. That's why each job depends on each other through "needs".
+name: nightly
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  schedule:
+    - cron: '0 1 * * 0' # every sunday at 1am
+
+env:
+  NIGHTLY_BUILD: 1
+
+jobs:
+  buildx:
+    uses: ./.github/workflows/.release.yml
+    with:
+      name: buildx
+    secrets: inherit
+
+  compose:
+    uses: ./.github/workflows/.release.yml
+    needs: buildx
+    with:
+      name: compose
+    secrets: inherit
+
+  containerd:
+    uses: ./.github/workflows/.release.yml
+    needs: compose
+    with:
+      name: containerd
+    secrets: inherit
+
+  credential-helpers:
+    uses: ./.github/workflows/.release.yml
+    needs: containerd
+    with:
+      name: credential-helpers
+    secrets: inherit
+
+  docker-cli:
+    uses: ./.github/workflows/.release.yml
+    needs: credential-helpers
+    with:
+      name: docker-cli
+    secrets: inherit
+
+  docker-engine:
+    uses: ./.github/workflows/.release.yml
+    needs: docker-cli
+    with:
+      name: docker-engine
+    secrets: inherit
+
+  sbom:
+    uses: ./.github/workflows/.release.yml
+    needs: docker-engine
+    with:
+      name: sbom
+    secrets: inherit
+
+  scan:
+    uses: ./.github/workflows/.release.yml
+    needs: sbom
+    with:
+      name: scan
+    secrets: inherit

--- a/.github/workflows/release-buildx.yml
+++ b/.github/workflows/release-buildx.yml
@@ -5,8 +5,6 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  schedule:
-    - cron: '0 1 * * 0' # every sunday at 1am
   workflow_dispatch:
     inputs:
       ref:
@@ -23,8 +21,7 @@ on:
         type: boolean
 
 jobs:
-  manual:
-    if: github.event_name == 'workflow_dispatch'
+  release:
     uses: ./.github/workflows/.release.yml
     with:
       name: buildx
@@ -32,13 +29,4 @@ jobs:
       env: |
         BUILDX_REPO=${{ inputs.repo }}
         BUILDX_REF=${{ inputs.ref }}
-    secrets: inherit
-
-  schedule:
-    if: github.event_name == 'schedule'
-    uses: ./.github/workflows/.release.yml
-    with:
-      name: buildx
-      env: |
-        NIGHTLY_BUILD=1
     secrets: inherit

--- a/.github/workflows/release-compose.yml
+++ b/.github/workflows/release-compose.yml
@@ -5,8 +5,6 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  schedule:
-    - cron: '0 2 * * 0' # every sunday at 2am
   workflow_dispatch:
     inputs:
       ref:
@@ -23,8 +21,7 @@ on:
         type: boolean
 
 jobs:
-  manual:
-    if: github.event_name == 'workflow_dispatch'
+  release:
     uses: ./.github/workflows/.release.yml
     with:
       name: compose
@@ -32,13 +29,4 @@ jobs:
       env: |
         COMPOSE_REPO=${{ inputs.repo }}
         COMPOSE_REF=${{ inputs.ref }}
-    secrets: inherit
-
-  schedule:
-    if: github.event_name == 'schedule'
-    uses: ./.github/workflows/.release.yml
-    with:
-      name: compose
-      env: |
-        NIGHTLY_BUILD=1
     secrets: inherit

--- a/.github/workflows/release-containerd.yml
+++ b/.github/workflows/release-containerd.yml
@@ -5,8 +5,6 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  schedule:
-    - cron: '0 3 * * 0' # every sunday at 3am
   workflow_dispatch:
     inputs:
       ref:
@@ -31,8 +29,7 @@ on:
         type: boolean
 
 jobs:
-  manual:
-    if: github.event_name == 'workflow_dispatch'
+  release:
     uses: ./.github/workflows/.release.yml
     with:
       name: containerd
@@ -42,13 +39,4 @@ jobs:
         CONTAINERD_REF=${{ inputs.ref }}
         RUNC_REPO=${{ inputs.runc_repo }}
         RUNC_REF=${{ inputs.runc_ref }}
-    secrets: inherit
-
-  schedule:
-    if: github.event_name == 'schedule'
-    uses: ./.github/workflows/.release.yml
-    with:
-      name: containerd
-      env: |
-        NIGHTLY_BUILD=1
     secrets: inherit

--- a/.github/workflows/release-credential-helpers.yml
+++ b/.github/workflows/release-credential-helpers.yml
@@ -5,8 +5,6 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  schedule:
-    - cron: '0 4 * * 0' # every sunday at 4am
   workflow_dispatch:
     inputs:
       ref:
@@ -23,8 +21,7 @@ on:
         type: boolean
 
 jobs:
-  manual:
-    if: github.event_name == 'workflow_dispatch'
+  release:
     uses: ./.github/workflows/.release.yml
     with:
       name: credential-helpers
@@ -32,13 +29,4 @@ jobs:
       env: |
         CREDENTIAL_HELPERS_REPO=${{ inputs.repo }}
         CREDENTIAL_HELPERS_REF=${{ inputs.ref }}
-    secrets: inherit
-
-  schedule:
-    if: github.event_name == 'schedule'
-    uses: ./.github/workflows/.release.yml
-    with:
-      name: credential-helpers
-      env: |
-        NIGHTLY_BUILD=1
     secrets: inherit

--- a/.github/workflows/release-docker-cli.yml
+++ b/.github/workflows/release-docker-cli.yml
@@ -5,8 +5,6 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  schedule:
-    - cron: '0 5 * * 0' # every sunday at 5am
   workflow_dispatch:
     inputs:
       ref:
@@ -23,8 +21,7 @@ on:
         type: boolean
 
 jobs:
-  manual:
-    if: github.event_name == 'workflow_dispatch'
+  release:
     uses: ./.github/workflows/.release.yml
     with:
       name: docker-cli
@@ -32,13 +29,4 @@ jobs:
       env: |
         DOCKER_CLI_REPO=${{ inputs.repo }}
         DOCKER_CLI_REF=${{ inputs.ref }}
-    secrets: inherit
-
-  schedule:
-    if: github.event_name == 'schedule'
-    uses: ./.github/workflows/.release.yml
-    with:
-      name: docker-cli
-      env: |
-        NIGHTLY_BUILD=1
     secrets: inherit

--- a/.github/workflows/release-docker-engine.yml
+++ b/.github/workflows/release-docker-engine.yml
@@ -5,8 +5,6 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  schedule:
-    - cron: '0 6 * * 0' # every sunday at 6am
   workflow_dispatch:
     inputs:
       ref:
@@ -23,8 +21,7 @@ on:
         type: boolean
 
 jobs:
-  manual:
-    if: github.event_name == 'workflow_dispatch'
+  release:
     uses: ./.github/workflows/.release.yml
     with:
       name: docker-engine
@@ -32,13 +29,4 @@ jobs:
       env: |
         DOCKER_ENGINE_REPO=${{ inputs.repo }}
         DOCKER_ENGINE_REF=${{ inputs.ref }}
-    secrets: inherit
-
-  schedule:
-    if: github.event_name == 'schedule'
-    uses: ./.github/workflows/.release.yml
-    with:
-      name: docker-engine
-      env: |
-        NIGHTLY_BUILD=1
     secrets: inherit

--- a/.github/workflows/release-sbom.yml
+++ b/.github/workflows/release-sbom.yml
@@ -5,8 +5,6 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  schedule:
-    - cron: '0 7 * * 0' # every sunday at 7am
   workflow_dispatch:
     inputs:
       ref:
@@ -23,8 +21,7 @@ on:
         type: boolean
 
 jobs:
-  manual:
-    if: github.event_name == 'workflow_dispatch'
+  release:
     uses: ./.github/workflows/.release.yml
     with:
       name: sbom
@@ -32,13 +29,4 @@ jobs:
       env: |
         SBOM_REPO=${{ inputs.repo }}
         SBOM_REF=${{ inputs.ref }}
-    secrets: inherit
-
-  schedule:
-    if: github.event_name == 'schedule'
-    uses: ./.github/workflows/.release.yml
-    with:
-      name: sbom
-      env: |
-        NIGHTLY_BUILD=1
     secrets: inherit

--- a/.github/workflows/release-scan.yml
+++ b/.github/workflows/release-scan.yml
@@ -5,8 +5,6 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  schedule:
-    - cron: '0 8 * * 0' # every sunday at 8am
   workflow_dispatch:
     inputs:
       ref:
@@ -23,8 +21,7 @@ on:
         type: boolean
 
 jobs:
-  manual:
-    if: github.event_name == 'workflow_dispatch'
+  release:
     uses: ./.github/workflows/.release.yml
     with:
       name: scan
@@ -32,13 +29,4 @@ jobs:
       env: |
         SCAN_REPO=${{ inputs.repo }}
         SCAN_REF=${{ inputs.ref }}
-    secrets: inherit
-
-  schedule:
-    if: github.event_name == 'schedule'
-    uses: ./.github/workflows/.release.yml
-    with:
-      name: scan
-      env: |
-        NIGHTLY_BUILD=1
     secrets: inherit


### PR DESCRIPTION
Removes cron from release workflow for each package and create a dedicated nightly workflow instead. This will avoid having the `run_number` in [GitHub Releases](https://github.com/docker/packaging/releases) being incremented for every nighty and release build:

https://github.com/docker/packaging/blob/71f00b0e2e09546db3d8bbbcca776f1238015bc6/.github/workflows/.release.yml#L224

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>