### PR TITLE
ci: fix release workflow

### DIFF
--- a/.github/workflows/.release.yml
+++ b/.github/workflows/.release.yml
@@ -133,6 +133,15 @@ jobs:
         run: |
           make -C pkg/${{ inputs.name }} metadata
       -
+        name: Set tag and version
+        run: |
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            echo "GIT_TAG=nightly/${{ inputs.name }}/$VERSION" >> $GITHUB_ENV
+          else
+            echo "GIT_TAG=${{ inputs.name }}/$VERSION" >> $GITHUB_ENV
+          fi
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+      -
         name: List artifacts
         run: |
           tree -nh ./pkg/${{ inputs.name }}/bin | tee /tmp/packages.txt
@@ -213,12 +222,6 @@ jobs:
           * size: \`$(du -sh ./pkg/${{ inputs.name }}/bin | awk '{print $1}')\`
           EOF
 
-          if [ "${{ github.event_name }}" = "schedule" ]; then
-            echo "GIT_TAG=nightly/${{ inputs.name }}/$VERSION" >> $GITHUB_ENV
-          else
-            echo "GIT_TAG=${{ inputs.name }}/$VERSION" >> $GITHUB_ENV
-          fi
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
           cat /tmp/summary.txt >> $GITHUB_STEP_SUMMARY
       -
         name: Set outputs

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,6 +19,8 @@ jobs:
     uses: ./.github/workflows/.release.yml
     with:
       name: buildx
+      env: |
+        NIGHTLY_BUILD=${{ env.NIGHTLY_BUILD }}
     secrets: inherit
 
   compose:
@@ -26,6 +28,8 @@ jobs:
     needs: buildx
     with:
       name: compose
+      env: |
+        NIGHTLY_BUILD=${{ env.NIGHTLY_BUILD }}
     secrets: inherit
 
   containerd:
@@ -33,6 +37,8 @@ jobs:
     needs: compose
     with:
       name: containerd
+      env: |
+        NIGHTLY_BUILD=${{ env.NIGHTLY_BUILD }}
     secrets: inherit
 
   credential-helpers:
@@ -40,6 +46,8 @@ jobs:
     needs: containerd
     with:
       name: credential-helpers
+      env: |
+        NIGHTLY_BUILD=${{ env.NIGHTLY_BUILD }}
     secrets: inherit
 
   docker-cli:
@@ -47,6 +55,8 @@ jobs:
     needs: credential-helpers
     with:
       name: docker-cli
+      env: |
+        NIGHTLY_BUILD=${{ env.NIGHTLY_BUILD }}
     secrets: inherit
 
   docker-engine:
@@ -54,6 +64,8 @@ jobs:
     needs: docker-cli
     with:
       name: docker-engine
+      env: |
+        NIGHTLY_BUILD=${{ env.NIGHTLY_BUILD }}
     secrets: inherit
 
   sbom:
@@ -61,6 +73,8 @@ jobs:
     needs: docker-engine
     with:
       name: sbom
+      env: |
+        NIGHTLY_BUILD=${{ env.NIGHTLY_BUILD }}
     secrets: inherit
 
   scan:
@@ -68,4 +82,6 @@ jobs:
     needs: sbom
     with:
       name: scan
+      env: |
+        NIGHTLY_BUILD=${{ env.NIGHTLY_BUILD }}
     secrets: inherit


### PR DESCRIPTION
fixes https://github.com/docker/packaging/actions/runs/4154080256/jobs/7186333348#step:10:184

```
/usr/bin/docker buildx bake --file ./docker-bake.hcl --file /tmp/docker-metadata-action-7H7B93/docker-metadata-action-bake.json --set *.output=type=image,push=true --metadata-file /tmp/docker-build-push-T6xmKB/metadata-file release
ERROR: invalid tag "dockereng/packaging:-5": invalid reference format
Error: buildx bake failed with: ERROR: invalid tag "dockereng/packaging:-5": invalid reference format
```

Also fixes env vars not being propagated. This is a known limitation with reusable workflows: https://docs.github.com/en/actions/using-workflows/reusing-workflows#limitations