### PR TITLE
pkg: containerd now depends on kernel headers instead of libbtrfs

### DIFF
--- a/pkg/containerd/Dockerfile
+++ b/pkg/containerd/Dockerfile
@@ -210,7 +210,7 @@ ARG NIGHTLY_BUILD
 ARG RUNC_REF
 WORKDIR /build
 ARG TARGETPLATFORM
-RUN xx-apt-get install -y libbtrfs-dev libseccomp-dev btrfs-progs gcc
+RUN xx-apt-get install -y libseccomp-dev gcc
 RUN --mount=type=bind,source=scripts/pkg-static-build.sh,target=/usr/local/bin/pkg-static-build \
     --mount=type=bind,from=common-scripts,source=gen-ver.sh,target=/usr/local/bin/gen-ver \
     --mount=type=bind,from=common-scripts,source=fix-cc.sh,target=/usr/local/bin/fix-cc \

--- a/pkg/containerd/deb/control
+++ b/pkg/containerd/deb/control
@@ -2,8 +2,7 @@ Source: containerd.io
 Section: devel
 Priority: optional
 Maintainer: Containerd team <help@containerd.io>
-Build-Depends: libbtrfs-dev | btrfs-tools,
-               debhelper (>= 10~) | dh-systemd,
+Build-Depends: debhelper (>= 10~) | dh-systemd,
                pkg-config,
                libseccomp-dev
 Standards-Version: 4.1.4

--- a/pkg/containerd/rpm/containerd.spec
+++ b/pkg/containerd/rpm/containerd.spec
@@ -69,16 +69,6 @@ BuildRequires: libtool-ltdl-devel
 BuildRequires: systemd
 BuildRequires: libseccomp-devel
 
-%if %{undefined rhel} || 0%{?rhel} < 8
-%if %{defined suse_version}
-# SUSE flavors
-BuildRequires: libbtrfs-devel
-%else
-# Fedora / others, and CentOS/RHEL < 8
-BuildRequires: btrfs-progs-devel
-%endif
-%endif
-
 %{?systemd_requires}
 
 %description
@@ -108,14 +98,7 @@ cd %{_topdir}/BUILD/
 %build
 cd %{_topdir}/BUILD
 GO111MODULE=auto make man
-
-BUILDTAGS=""
-%if %{defined rhel} && 0%{?rhel} >= 8
-# btrfs support was removed in CentOS/RHEL 8
-BUILDTAGS="${BUILDTAGS} no_btrfs"
-%endif
-
-GO111MODULE=auto make -C /go/src/%{import_path} VERSION=%{_origversion} REVISION=%{_commit} PACKAGE=%{getenv:PKG_NAME} BUILDTAGS="${BUILDTAGS}"
+GO111MODULE=auto make -C /go/src/%{import_path} VERSION=%{_origversion} REVISION=%{_commit} PACKAGE=%{getenv:PKG_NAME} BUILDTAGS="%{getenv:BUILDTAGS}"
 
 # Remove containerd-stress, as we're not shipping it as part of the packages
 rm -f bin/containerd-stress

--- a/pkg/containerd/scripts/pkg-rpm-build.sh
+++ b/pkg/containerd/scripts/pkg-rpm-build.sh
@@ -66,6 +66,12 @@ if [ -n "$(xx-info variant)" ]; then
   pkgoutput="${pkgoutput}/$(xx-info variant)"
 fi
 
+case "$PKG_RELEASE" in
+  centos*|oraclelinux*)
+    export BUILDTAGS="no_btrfs $BUILDTAGS"
+    ;;
+esac
+
 set -x
 
 sed 's#/usr/local/bin/containerd#/usr/bin/containerd#g' "${SRCDIR}/containerd.service" > /root/rpmbuild/SOURCES/containerd.service


### PR DESCRIPTION
fixes #87 

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>