### PR TITLE
ci: fix env key in reusable workflows

### DIFF
--- a/.github/workflows/.build.yml
+++ b/.github/workflows/.build.yml
@@ -7,6 +7,9 @@ on:
       name:
         required: true
         type: string
+      envs:
+        required: false
+        type: string
 
 env:
   BUILD_CACHE_REGISTRY_SLUG: dockereng/packaging-cache
@@ -48,6 +51,12 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v3
+      -
+        name: Environment variables
+        run: |
+          for l in "${{ inputs.envs }}"; do
+            echo "${l?}" >> $GITHUB_ENV
+          done
       -
         name: Prepare
         run: |
@@ -106,6 +115,12 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v3
+      -
+        name: Environment variables
+        run: |
+          for l in "${{ inputs.envs }}"; do
+            echo "${l?}" >> $GITHUB_ENV
+          done
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/.release.yml
+++ b/.github/workflows/.release.yml
@@ -7,7 +7,7 @@ on:
       name:
         required: true
         type: string
-      env:
+      envs:
         required: false
         type: string
       release:
@@ -53,7 +53,7 @@ jobs:
       -
         name: Environment variables
         run: |
-          for l in "${{ inputs.env }}"; do
+          for l in "${{ inputs.envs }}"; do
             echo "${l?}" >> $GITHUB_ENV
           done
       -
@@ -119,7 +119,7 @@ jobs:
       -
         name: Environment variables
         run: |
-          for l in "${{ inputs.env }}"; do
+          for l in "${{ inputs.envs }}"; do
             echo "${l?}" >> $GITHUB_ENV
           done
       -

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,7 +28,7 @@ jobs:
     needs: buildx
     with:
       name: compose
-      env: |
+      envs: |
         NIGHTLY_BUILD=${{ env.NIGHTLY_BUILD }}
     secrets: inherit
 
@@ -37,7 +37,7 @@ jobs:
     needs: compose
     with:
       name: containerd
-      env: |
+      envs: |
         NIGHTLY_BUILD=${{ env.NIGHTLY_BUILD }}
     secrets: inherit
 
@@ -46,7 +46,7 @@ jobs:
     needs: containerd
     with:
       name: credential-helpers
-      env: |
+      envs: |
         NIGHTLY_BUILD=${{ env.NIGHTLY_BUILD }}
     secrets: inherit
 
@@ -55,7 +55,7 @@ jobs:
     needs: credential-helpers
     with:
       name: docker-cli
-      env: |
+      envs: |
         NIGHTLY_BUILD=${{ env.NIGHTLY_BUILD }}
     secrets: inherit
 
@@ -64,7 +64,7 @@ jobs:
     needs: docker-cli
     with:
       name: docker-engine
-      env: |
+      envs: |
         NIGHTLY_BUILD=${{ env.NIGHTLY_BUILD }}
     secrets: inherit
 
@@ -73,7 +73,7 @@ jobs:
     needs: docker-engine
     with:
       name: sbom
-      env: |
+      envs: |
         NIGHTLY_BUILD=${{ env.NIGHTLY_BUILD }}
     secrets: inherit
 
@@ -82,6 +82,6 @@ jobs:
     needs: sbom
     with:
       name: scan
-      env: |
+      envs: |
         NIGHTLY_BUILD=${{ env.NIGHTLY_BUILD }}
     secrets: inherit

--- a/.github/workflows/release-buildx.yml
+++ b/.github/workflows/release-buildx.yml
@@ -26,7 +26,7 @@ jobs:
     with:
       name: buildx
       release: ${{ inputs.release }}
-      env: |
+      envs: |
         BUILDX_REPO=${{ inputs.repo }}
         BUILDX_REF=${{ inputs.ref }}
     secrets: inherit

--- a/.github/workflows/release-compose.yml
+++ b/.github/workflows/release-compose.yml
@@ -26,7 +26,7 @@ jobs:
     with:
       name: compose
       release: ${{ inputs.release }}
-      env: |
+      envs: |
         COMPOSE_REPO=${{ inputs.repo }}
         COMPOSE_REF=${{ inputs.ref }}
     secrets: inherit

--- a/.github/workflows/release-containerd.yml
+++ b/.github/workflows/release-containerd.yml
@@ -34,7 +34,7 @@ jobs:
     with:
       name: containerd
       release: ${{ inputs.release }}
-      env: |
+      envs: |
         CONTAINERD_REPO=${{ inputs.repo }}
         CONTAINERD_REF=${{ inputs.ref }}
         RUNC_REPO=${{ inputs.runc_repo }}

--- a/.github/workflows/release-credential-helpers.yml
+++ b/.github/workflows/release-credential-helpers.yml
@@ -26,7 +26,7 @@ jobs:
     with:
       name: credential-helpers
       release: ${{ inputs.release }}
-      env: |
+      envs: |
         CREDENTIAL_HELPERS_REPO=${{ inputs.repo }}
         CREDENTIAL_HELPERS_REF=${{ inputs.ref }}
     secrets: inherit

--- a/.github/workflows/release-docker-cli.yml
+++ b/.github/workflows/release-docker-cli.yml
@@ -26,7 +26,7 @@ jobs:
     with:
       name: docker-cli
       release: ${{ inputs.release }}
-      env: |
+      envs: |
         DOCKER_CLI_REPO=${{ inputs.repo }}
         DOCKER_CLI_REF=${{ inputs.ref }}
     secrets: inherit

--- a/.github/workflows/release-docker-engine.yml
+++ b/.github/workflows/release-docker-engine.yml
@@ -26,7 +26,7 @@ jobs:
     with:
       name: docker-engine
       release: ${{ inputs.release }}
-      env: |
+      envs: |
         DOCKER_ENGINE_REPO=${{ inputs.repo }}
         DOCKER_ENGINE_REF=${{ inputs.ref }}
     secrets: inherit

--- a/.github/workflows/release-sbom.yml
+++ b/.github/workflows/release-sbom.yml
@@ -26,7 +26,7 @@ jobs:
     with:
       name: sbom
       release: ${{ inputs.release }}
-      env: |
+      envs: |
         SBOM_REPO=${{ inputs.repo }}
         SBOM_REF=${{ inputs.ref }}
     secrets: inherit

--- a/.github/workflows/release-scan.yml
+++ b/.github/workflows/release-scan.yml
@@ -26,7 +26,7 @@ jobs:
     with:
       name: scan
       release: ${{ inputs.release }}
-      env: |
+      envs: |
         SCAN_REPO=${{ inputs.repo }}
         SCAN_REF=${{ inputs.ref }}
     secrets: inherit


### PR DESCRIPTION
Saw this in nightly build workflow:

```
Invalid workflow file: .github/workflows/nightly.yml#L22
The workflow is not valid. .github/workflows/nightly.yml (Line: 22, Col: 12): Unrecognized named-value: 'env'. Located at position 1 within expression: env.NIGHTLY_BUILD .github/workflows/nightly.yml (Line: 31, Col: 12): Unrecognized named-value: 'env'. Located at position 1 within expression: env.NIGHTLY_BUILD
```

Seems GitHub made `env` key reserved recently.