### PR TITLE
Move "docker-init" into appropriate "libexec" directory

### DIFF
--- a/pkg/docker-engine/deb/rules
+++ b/pkg/docker-engine/deb/rules
@@ -24,7 +24,7 @@ override_dh_auto_install:
 	install -D -m 0644 /common/systemd/docker.socket debian/docker-ce/lib/systemd/system/docker.socket
 	install -D -m 0755 $(shell readlink -e engine/bundles/dynbinary-daemon/dockerd) debian/docker-ce/usr/bin/dockerd
 	install -D -m 0755 $(shell readlink -e engine/bundles/dynbinary-daemon/docker-proxy) debian/docker-ce/usr/bin/docker-proxy
-	install -D -m 0755 /usr/local/bin/docker-init debian/docker-ce/usr/bin/docker-init
+	install -D -m 0755 /usr/local/bin/docker-init debian/docker-ce/usr/libexec/docker/docker-init
 
 	# docker-ce-rootless-extras install
 	install -D -m 0755 /usr/local/bin/rootlesskit debian/docker-ce-rootless-extras/usr/bin/rootlesskit

--- a/pkg/docker-engine/rpm/docker-ce.spec
+++ b/pkg/docker-engine/rpm/docker-ce.spec
@@ -88,7 +88,7 @@ ver="$(engine/bundles/dynbinary-daemon/dockerd --version)"; \
 # install binaries
 install -D -p -m 0755 $(readlink -f engine/bundles/dynbinary-daemon/dockerd) ${RPM_BUILD_ROOT}%{_bindir}/dockerd
 install -D -p -m 0755 $(readlink -f engine/bundles/dynbinary-daemon/docker-proxy) ${RPM_BUILD_ROOT}%{_bindir}/docker-proxy
-install -D -p -m 0755 /usr/local/bin/docker-init ${RPM_BUILD_ROOT}%{_bindir}/docker-init
+install -D -p -m 0755 /usr/local/bin/docker-init ${RPM_BUILD_ROOT}%{_libexecdir}/docker/docker-init
 
 # install systemd scripts
 install -D -m 0644 engine/contrib/init/systemd/docker.service ${RPM_BUILD_ROOT}%{_unitdir}/docker.service
@@ -97,7 +97,7 @@ install -D -m 0644 engine/contrib/init/systemd/docker.socket ${RPM_BUILD_ROOT}%{
 %files
 %{_bindir}/dockerd
 %{_bindir}/docker-proxy
-%{_bindir}/docker-init
+%{_libexecdir}/docker/docker-init
 %{_unitdir}/docker.service
 %{_unitdir}/docker.socket
 


### PR DESCRIPTION
See https://github.com/moby/moby/commit/6caaa8cadc9e4f1e122b7b2bb4451500bbec6086 / https://github.com/moby/moby/pull/45198 / https://github.com/docker/docker-ce-packaging/pull/868