### PR TITLE
[docker/23.0 backport] pkg(docker-cli): remove scan plugin from recommends

### DIFF
--- a/pkg/docker-cli/deb/control
+++ b/pkg/docker-cli/deb/control
@@ -16,10 +16,8 @@ Build-Depends: bash,
 Package: docker-ce-cli
 Architecture: linux-any
 Depends: ${shlibs:Depends}
-# TODO change once we support scan-plugin on other architectures
 Recommends: docker-buildx-plugin,
-            docker-compose-plugin,
-            docker-scan-plugin [amd64]
+            docker-compose-plugin
 Conflicts: docker (<< 1.5~),
            docker-engine,
            docker-engine-cs,

--- a/pkg/docker-cli/rpm/docker-ce-cli.spec
+++ b/pkg/docker-cli/rpm/docker-ce-cli.spec
@@ -27,19 +27,6 @@ Recommends: docker-buildx-plugin
 Recommends: docker-compose-plugin
 %endif
 
-# TODO change once we support scan-plugin on other architectures
-%ifarch x86_64
-# CentOS 7 and RHEL 7 do not yet support weak dependencies
-#
-# Note that we're not using <= 7 here, to account for other RPM distros, such
-# as Fedora, which would not have the rhel macro set (so default to 0).
-%if 0%{?rhel} == 7
-Requires: docker-scan-plugin(x86-64)
-%else
-Recommends: docker-scan-plugin(x86-64)
-%endif
-%endif
-
 BuildRequires: gcc
 BuildRequires: libtool-ltdl-devel
 BuildRequires: make


### PR DESCRIPTION
* backport of https://github.com/docker/packaging/pull/116
