### PR TITLE
[docker/24.0] pkg(docker-cli,docker-engine): fix default ref to 24.0

### DIFF
--- a/pkg/docker-cli/Makefile
+++ b/pkg/docker-cli/Makefile
@@ -21,7 +21,7 @@ DESTDIR ?= $(BASEDIR)/bin
 BAKE_DEFINITIONS ?= -f docker-bake.hcl -f ../../common/packages.hcl
 
 export DOCKER_CLI_REPO := $(if $(DOCKER_CLI_REPO),$(DOCKER_CLI_REPO),https://github.com/docker/cli.git)
-export DOCKER_CLI_REF := $(if $(DOCKER_CLI_REF),$(DOCKER_CLI_REF),master)
+export DOCKER_CLI_REF := $(if $(DOCKER_CLI_REF),$(DOCKER_CLI_REF),24.0)
 
 export PKG_DEB_REVISION = 3
 export PKG_RPM_RELEASE = 3

--- a/pkg/docker-cli/docker-bake.hcl
+++ b/pkg/docker-cli/docker-bake.hcl
@@ -21,7 +21,7 @@ variable "DOCKER_CLI_REPO" {
 
 # Sets the docker cli ref.
 variable "DOCKER_CLI_REF" {
-  default = "master"
+  default = "24.0"
 }
 
 # set to 1 to enforce nightly build

--- a/pkg/docker-engine/Makefile
+++ b/pkg/docker-engine/Makefile
@@ -21,7 +21,7 @@ DESTDIR ?= $(BASEDIR)/bin
 BAKE_DEFINITIONS ?= -f docker-bake.hcl -f ../../common/packages.hcl
 
 export DOCKER_ENGINE_REPO := $(if $(DOCKER_ENGINE_REPO),$(DOCKER_ENGINE_REPO),https://github.com/docker/docker.git)
-export DOCKER_ENGINE_REF := $(if $(DOCKER_ENGINE_REF),$(DOCKER_ENGINE_REF),master)
+export DOCKER_ENGINE_REF := $(if $(DOCKER_ENGINE_REF),$(DOCKER_ENGINE_REF),24.0)
 
 export PKG_DEB_REVISION = 3
 export PKG_RPM_RELEASE = 3

--- a/pkg/docker-engine/docker-bake.hcl
+++ b/pkg/docker-engine/docker-bake.hcl
@@ -21,7 +21,7 @@ variable "DOCKER_ENGINE_REPO" {
 
 # Sets the docker engine ref.
 variable "DOCKER_ENGINE_REF" {
-  default = "master"
+  default = "24.0"
 }
 
 # set to 1 to enforce nightly build


### PR DESCRIPTION
created https://github.com/docker/packaging/tree/docker/24.0 branch so enforce default ref to `24.0`