### PR TITLE
[containerd/1.7] pkg(containerd): fix default ref to release/1.7

### DIFF
--- a/pkg/containerd/Makefile
+++ b/pkg/containerd/Makefile
@@ -21,7 +21,7 @@ DESTDIR ?= $(BASEDIR)/bin
 BAKE_DEFINITIONS ?= -f docker-bake.hcl -f ../../common/packages.hcl
 
 export CONTAINERD_REPO := $(if $(CONTAINERD_REPO),$(CONTAINERD_REPO),https://github.com/containerd/containerd.git)
-export CONTAINERD_REF := $(if $(CONTAINERD_REF),$(CONTAINERD_REF),main)
+export CONTAINERD_REF := $(if $(CONTAINERD_REF),$(CONTAINERD_REF),release/1.7)
 export RUNC_REPO := $(if $(RUNC_REPO),$(RUNC_REPO),https://github.com/opencontainers/runc.git)
 export RUNC_REF := $(if $(RUNC_REF),$(RUNC_REF),)
 

--- a/pkg/containerd/docker-bake.hcl
+++ b/pkg/containerd/docker-bake.hcl
@@ -21,7 +21,7 @@ variable "CONTAINERD_REPO" {
 
 # Sets the containerd ref.
 variable "CONTAINERD_REF" {
-  default = "main"
+  default = "release/1.7"
 }
 
 # In case we want to set runc to a specific version instead of using


### PR DESCRIPTION
created https://github.com/docker/packaging/tree/container/1.7 branch so enforce default ref to `1.7`