### PR TITLE
disable s390x releases

### DIFF
--- a/.github/workflows/.release.yml
+++ b/.github/workflows/.release.yml
@@ -77,16 +77,16 @@ jobs:
             - name: aws_graviton2
               endpoint: tcp://${{ secrets.AWS_ARM64_HOST }}:1234
               platforms: darwin/arm64,linux/arm64,linux/arm/v5,linux/arm/v6,linux/arm/v7,windows/arm64
-            - name: linuxone_s390x
-              endpoint: tcp://${{ secrets.LINUXONE_S390X_HOST }}:1234
-              platforms: linux/s390x
+#            - name: linuxone_s390x
+#              endpoint: tcp://${{ secrets.LINUXONE_S390X_HOST }}:1234
+#              platforms: linux/s390x
         env:
           BUILDER_NODE_1_AUTH_TLS_CACERT: ${{ secrets.AWS_ARM64_CACERT }}
           BUILDER_NODE_1_AUTH_TLS_CERT: ${{ secrets.AWS_ARM64_CERT }}
           BUILDER_NODE_1_AUTH_TLS_KEY: ${{ secrets.AWS_ARM64_KEY }}
-          BUILDER_NODE_2_AUTH_TLS_CACERT: ${{ secrets.LINUXONE_S390X_CACERT }}
-          BUILDER_NODE_2_AUTH_TLS_CERT: ${{ secrets.LINUXONE_S390X_CERT }}
-          BUILDER_NODE_2_AUTH_TLS_KEY: ${{ secrets.LINUXONE_S390X_KEY }}
+#          BUILDER_NODE_2_AUTH_TLS_CACERT: ${{ secrets.LINUXONE_S390X_CACERT }}
+#          BUILDER_NODE_2_AUTH_TLS_CERT: ${{ secrets.LINUXONE_S390X_CERT }}
+#          BUILDER_NODE_2_AUTH_TLS_KEY: ${{ secrets.LINUXONE_S390X_KEY }}
       -
         name: Build
         run: |

--- a/pkg/buildx/Makefile
+++ b/pkg/buildx/Makefile
@@ -26,7 +26,8 @@ export BUILDX_REF := $(if $(BUILDX_REF),$(BUILDX_REF),master)
 PKG_LIST ?= deb rpm static
 # supported platforms: https://github.com/docker/buildx/blob/master/docker-bake.hcl#L110-L122
 # FIXME: add linux/ppc64le when a remote PowerPC instance is available (too slow with QEMU)
-PKG_PLATFORMS ?= darwin/amd64 darwin/arm64 linux/amd64 linux/arm/v5 linux/arm/v6 linux/arm/v7 linux/arm64 linux/riscv64 linux/s390x windows/amd64 windows/arm64
+# FIXME: add linux/s390x when remote instance is reachable again (too slow with QEMU)
+PKG_PLATFORMS ?= darwin/amd64 darwin/arm64 linux/amd64 linux/arm/v5 linux/arm/v6 linux/arm/v7 linux/arm64 linux/riscv64 windows/amd64 windows/arm64
 
 .PHONY: default
 default: pkg ;

--- a/pkg/compose/Makefile
+++ b/pkg/compose/Makefile
@@ -26,7 +26,8 @@ export COMPOSE_REF := $(if $(COMPOSE_REF),$(COMPOSE_REF),v2)
 PKG_LIST ?= deb rpm static
 # supported platforms: https://github.com/docker/compose/blob/v2/docker-bake.hcl#L95-L107
 # FIXME: add linux/ppc64le when a remote PowerPC instance is available (too slow with QEMU)
-PKG_PLATFORMS ?= darwin/amd64 darwin/arm64 linux/amd64 linux/arm/v5 linux/arm/v6 linux/arm/v7 linux/arm64 linux/riscv64 linux/s390x windows/amd64 windows/arm64
+# FIXME: add linux/s390x when remote instance is reachable again (too slow with QEMU)
+PKG_PLATFORMS ?= darwin/amd64 darwin/arm64 linux/amd64 linux/arm/v5 linux/arm/v6 linux/arm/v7 linux/arm64 linux/riscv64 windows/amd64 windows/arm64
 
 .PHONY: default
 default: pkg ;

--- a/pkg/containerd/Makefile
+++ b/pkg/containerd/Makefile
@@ -32,7 +32,8 @@ PKG_LIST ?= deb rpm static
 # FIXME: can't build static binaries with containerd Makefile for darwin/amd64 darwin/arm64 windows/amd64 platforms
 # FIXME: linux/riscv64 needs ubuntu:22.04 image
 # FIXME: add linux/ppc64le when a remote PowerPC instance is available (too slow with QEMU)
-PKG_PLATFORMS ?= linux/amd64 linux/arm/v5 linux/arm/v6 linux/arm/v7 linux/arm64 linux/s390x
+# FIXME: add linux/s390x when remote instance is reachable again (too slow with QEMU)
+PKG_PLATFORMS ?= linux/amd64 linux/arm/v5 linux/arm/v6 linux/arm/v7 linux/arm64
 
 .PHONY: default
 default: pkg ;

--- a/pkg/credential-helpers/Makefile
+++ b/pkg/credential-helpers/Makefile
@@ -26,7 +26,8 @@ export CREDENTIAL_HELPERS_REF := $(if $(CREDENTIAL_HELPERS_REF),$(CREDENTIAL_HEL
 PKG_LIST ?= deb rpm static
 # supported platforms: https://github.com/docker/docker-credential-helpers/blob/master/docker-bake.hcl#L56-L66
 # FIXME: add linux/ppc64le when a remote PowerPC instance is available (too slow with QEMU)
-PKG_PLATFORMS ?= darwin/amd64 darwin/arm64 linux/amd64 linux/arm/v5 linux/arm/v6 linux/arm/v7 linux/arm64 linux/s390x windows/amd64
+# FIXME: add linux/s390x when remote instance is reachable again (too slow with QEMU)
+PKG_PLATFORMS ?= darwin/amd64 darwin/arm64 linux/amd64 linux/arm/v5 linux/arm/v6 linux/arm/v7 linux/arm64 windows/amd64
 
 .PHONY: default
 default: pkg ;

--- a/pkg/docker-cli/Makefile
+++ b/pkg/docker-cli/Makefile
@@ -29,7 +29,8 @@ export PKG_RPM_RELEASE = 3
 PKG_LIST ?= deb rpm static
 # supported platforms: https://github.com/docker/cli/blob/master/docker-bake.hcl#L30-L42
 # FIXME: add linux/ppc64le when a remote PowerPC instance is available (too slow with QEMU)
-PKG_PLATFORMS ?= darwin/amd64 darwin/arm64 linux/386 linux/amd64 linux/arm/v5 linux/arm/v6 linux/arm/v7 linux/arm64 linux/riscv64 linux/s390x windows/amd64 windows/arm64
+# FIXME: add linux/s390x when remote instance is reachable again (too slow with QEMU)
+PKG_PLATFORMS ?= darwin/amd64 darwin/arm64 linux/386 linux/amd64 linux/arm/v5 linux/arm/v6 linux/arm/v7 linux/arm64 linux/riscv64 windows/amd64 windows/arm64
 
 .PHONY: default
 default: pkg ;

--- a/pkg/docker-engine/Makefile
+++ b/pkg/docker-engine/Makefile
@@ -29,7 +29,8 @@ export PKG_RPM_RELEASE = 3
 PKG_LIST ?= deb rpm static
 # supported platforms: https://github.com/moby/moby/blob/master/docker-bake.hcl#L93-L101
 # FIXME: add linux/ppc64le when a remote PowerPC instance is available (too slow with QEMU)
-PKG_PLATFORMS ?= linux/amd64 linux/arm/v5 linux/arm/v6 linux/arm/v7 linux/arm64 linux/s390x windows/amd64
+# FIXME: add linux/s390x when remote instance is reachable again (too slow with QEMU)
+PKG_PLATFORMS ?= linux/amd64 linux/arm/v5 linux/arm/v6 linux/arm/v7 linux/arm64 windows/amd64
 
 .PHONY: default
 default: pkg ;


### PR DESCRIPTION
Our remote instance seems offline for quite some time. Let's disable release builds for this arch for now.