### PR TITLE
pkg(compose): fix go modules download for static pkg

### DIFF
--- a/pkg/compose/Dockerfile
+++ b/pkg/compose/Dockerfile
@@ -175,6 +175,12 @@ ARG PKG_NAME
 ARG COMPOSE_REF
 ARG NIGHTLY_BUILD
 WORKDIR /build
+# download dependencies before "ARG TARGETPLATFORM" otherwise it will be cached
+# for each platform and that would take a lot of disk space
+RUN --mount=type=bind,from=src,source=/src/go.mod,target=/build/go.mod \
+    --mount=type=bind,from=src,source=/src/go.mod,target=/build/go.sum,rw \
+    --mount=type=bind,from=gocross,source=/usr/local/go,target=/usr/local/go,rw \
+    go mod download -x
 ARG TARGETPLATFORM
 RUN xx-apt-get install -y gcc libc6-dev
 RUN --mount=type=bind,source=scripts/pkg-static-build.sh,target=/usr/local/bin/pkg-static-build \
@@ -200,6 +206,12 @@ ARG PKG_NAME
 ARG COMPOSE_REF
 ARG NIGHTLY_BUILD
 WORKDIR /build
+# download dependencies before "ARG TARGETPLATFORM" otherwise it will be cached
+# for each platform and that would take a lot of disk space
+RUN --mount=type=bind,from=src,source=/src/go.mod,target=/build/go.mod \
+    --mount=type=bind,from=src,source=/src/go.mod,target=/build/go.sum,rw \
+    --mount=type=bind,from=gocross,source=/usr/local/go,target=/usr/local/go,rw \
+    go mod download -x
 ARG TARGETPLATFORM
 RUN xx-apt-get install -y gcc libc6-dev
 RUN --mount=type=bind,source=scripts/pkg-static-build.sh,target=/usr/local/bin/pkg-static-build \


### PR DESCRIPTION
Found this issue in CI: https://github.com/docker/packaging/actions/runs/5758467430/job/15611066955#step:8:4656

```
------
 > [linux/amd64 builder-static-nosdk 6/6] RUN --mount=type=bind,source=scripts/pkg-static-build.sh,target=/usr/local/bin/pkg-static-build     --mount=type=bind,from=common-scripts,source=gen-ver.sh,target=/usr/local/bin/gen-ver     --mount=type=bind,from=common-scripts,source=fix-cc.sh,target=/usr/local/bin/fix-cc     --mount=type=bind,from=src,source=/src,target=/usr/local/src/compose     --mount=type=bind,from=gocross,source=/usr/local/go,target=/usr/local/go,rw     OUTDIR=/out BUILDDIR=/build SRCDIR=/usr/local/src/compose pkg-static-build:
827.3 github.com/buger/goterm: mkdir /tmp/go-build3973811788/b1013/: no space left on device
827.3 github.com/mattn/go-isatty: mkdir /tmp/go-build3973811788/b1019/: no space left on device
827.3 github.com/kballard/go-shellquote: mkdir /tmp/go-build3973811788/b1021/: no space left on device
827.3 golang.org/x/text/internal/tag: mkdir /tmp/go-build3973811788/b1026/: no space left on device
827.3 github.com/AlecAivazis/survey/v2/terminal: mkdir /tmp/go-build3973811788/b1020/: no space left on device
827.3 github.com/tilt-dev/fsnotify: mkdir /tmp/go-build3973811788/b1030/: no space left on device
827.3 github.com/jonboulle/clockwork: mkdir /tmp/go-build3973811788/b1031/: no space left on device
827.3 golang.org/x/crypto/nacl/sign: mkdir /tmp/go-build3973811788/b1034/: no space left on device
827.3 github.com/golang/mock/gomock: mkdir /tmp/go-build3973811788/b1028/: no space left on device
828.4 make: *** [Makefile:57: build] Error 1
```

As compose does not vendor modules we are downloading them for each platform being built which can take a significant amount of space.

Update the Dockerfile to download modules before `TARGETPLATFORM` handling so it runs once for the build platform.