### PR TITLE
distro: add ubuntu 23.10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ include common/packages.mk
 
 GHA_MATRIX ?= minimal
 ifeq ($(GHA_MATRIX),minimal)
-	GHA_RELEASES := debian10 debian11 debian12 ubuntu2004 ubuntu2204 ubuntu2304 centos7 centos9 oraclelinux7 fedora38 fedora39 static
+	GHA_RELEASES := debian10 debian11 debian12 ubuntu2004 ubuntu2204 ubuntu2304 ubuntu2310 centos7 centos9 oraclelinux7 fedora38 fedora39 static
 else ifeq ($(GHA_MATRIX),all)
 	GHA_RELEASES := $(PKG_DEB_RELEASES) $(PKG_RPM_RELEASES) static
 else

--- a/common/packages.hcl
+++ b/common/packages.hcl
@@ -163,6 +163,17 @@ target "_pkg-ubuntu2304" {
   }
 }
 
+target "_pkg-ubuntu2310" {
+  args = {
+    PKG_RELEASE = "ubuntu2310"
+    PKG_TYPE = "deb"
+    PKG_DISTRO = "ubuntu"
+    PKG_DISTRO_ID = "23.10"
+    PKG_DISTRO_SUITE = "mantic"
+    PKG_BASE_IMAGE = "ubuntu:mantic"
+  }
+}
+
 target "_pkg-centos7" {
   args = {
     PKG_RELEASE = "centos7"

--- a/common/packages.mk
+++ b/common/packages.mk
@@ -15,7 +15,7 @@
 # don't forget to add/update pkg-info-* rule and update packages.hcl as well
 # if you add a new release
 PKG_APK_RELEASES ?= alpine314 alpine315 alpine316
-PKG_DEB_RELEASES ?= debian10 debian11 debian12 ubuntu2004 ubuntu2204 ubuntu2304 raspbian10 raspbian11 raspbian12
+PKG_DEB_RELEASES ?= debian10 debian11 debian12 ubuntu2004 ubuntu2204 ubuntu2304 ubuntu2310 raspbian10 raspbian11 raspbian12
 PKG_RPM_RELEASES ?= centos7 centos8 centos9 fedora37 fedora38 fedora39 oraclelinux7 oraclelinux8 oraclelinux9
 
 # PKG_SUPPORTED_PLATFORMS could be replaced by:
@@ -145,6 +145,16 @@ pkg-info-ubuntu2304:
 	$(eval PKG_DISTRO_ID = 23.04)
 	$(eval PKG_DISTRO_SUITE = lunar)
 	$(eval PKG_BASE_IMAGE = ubuntu:lunar)
+	@# FIXME: linux/riscv64 is not supported (golang base image does not support riscv64)
+	$(eval PKG_SUPPORTED_PLATFORMS = linux/amd64 linux/arm64 linux/arm/v7 linux/ppc64le linux/s390x)
+
+.PHONY: pkg-info-ubuntu2310
+pkg-info-ubuntu2310:
+	$(eval PKG_TYPE = deb)
+	$(eval PKG_DISTRO = ubuntu)
+	$(eval PKG_DISTRO_ID = 23.10)
+	$(eval PKG_DISTRO_SUITE = mantic)
+	$(eval PKG_BASE_IMAGE = ubuntu:mantic)
 	@# FIXME: linux/riscv64 is not supported (golang base image does not support riscv64)
 	$(eval PKG_SUPPORTED_PLATFORMS = linux/amd64 linux/arm64 linux/arm/v7 linux/ppc64le linux/s390x)
 

--- a/pkg/docker-cli/Dockerfile
+++ b/pkg/docker-cli/Dockerfile
@@ -96,7 +96,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends apt-utils bash 
 RUN <<EOT
   set -e
   case "$PKG_RELEASE" in
-    ubuntu2004|ubuntu2204|ubuntu2304)
+    ubuntu2004|ubuntu2204|ubuntu2304|ubuntu2310)
       if [ "$(dpkg-divert --truename /usr/bin/man)" = "/usr/bin/man.REAL" ]; then
         rm -f /usr/bin/man
         dpkg-divert --quiet --remove --rename /usr/bin/man

--- a/pkg/docker-engine/Dockerfile
+++ b/pkg/docker-engine/Dockerfile
@@ -95,7 +95,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends apt-utils bash 
 RUN <<EOT
   set -e
   case "$PKG_RELEASE" in
-    ubuntu2004|ubuntu2204|ubuntu2304)
+    ubuntu2004|ubuntu2204|ubuntu2304|ubuntu2310)
       if [ "$(dpkg-divert --truename /usr/bin/man)" = "/usr/bin/man.REAL" ]; then
         rm -f /usr/bin/man
         dpkg-divert --quiet --remove --rename /usr/bin/man


### PR DESCRIPTION
relates to https://github.com/docker/docker-ce-packaging/pull/949
relates to https://github.com/docker/containerd-packaging/commit/68ea3734399c7701623f94d3c88794117185d8bb - https://github.com/docker/containerd-packaging/pull/328

Ubuntu 23.10 is planned to be released on October 12, 2023, but final betas are available now.