### PR TITLE
docker-engine: fix require with rpm "docker-ce-rootless-extras" pkg

### DIFF
--- a/pkg/docker-engine/rpm/docker-ce.spec
+++ b/pkg/docker-engine/rpm/docker-ce.spec
@@ -16,7 +16,15 @@ Packager: Docker <support@docker.com>
 
 Requires: /usr/sbin/groupadd
 Requires: docker-ce-cli
+# CentOS 7 and RHEL 7 do not yet support weak dependencies
+#
+# Note that we're not using <= 7 here, to account for other RPM distros, such
+# as Fedora, which would not have the rhel macro set (so default to 0).
+%if 0%{?rhel} == 7
 Requires: docker-ce-rootless-extras
+%else
+Recommends: docker-ce-rootless-extras
+%endif
 Requires: container-selinux >= 2:2.74
 Requires: libseccomp >= 2.3
 Requires: systemd


### PR DESCRIPTION
follow-up https://github.com/docker/docker-ce-packaging/pull/945