### PR TITLE
[containerd/1.6] bump go to 1.20.8

### DIFF
--- a/pkg/containerd/Dockerfile
+++ b/pkg/containerd/Dockerfile
@@ -17,12 +17,12 @@
 ARG XX_VERSION="1.2.1"
 ARG DEBIAN_FRONTEND="noninteractive"
 
-# https://github.com/containerd/containerd/blob/main/.github/workflows/ci.yml#L132
-ARG MD2MAN_VERSION="v2.0.2"
+# https://github.com/containerd/containerd/blob/release/1.6/.github/workflows/ci.yml#L133
+ARG MD2MAN_VERSION="v2.0.1"
 
 # common args
 ARG GO_IMAGE="golang"
-ARG GO_VERSION="1.19.12"
+ARG GO_VERSION="1.20.8"
 ARG GO_IMAGE_VARIANT="bullseye"
 ARG PKG_RELEASE="debian11"
 ARG PKG_TYPE="deb"

--- a/pkg/containerd/Makefile
+++ b/pkg/containerd/Makefile
@@ -15,7 +15,7 @@
 include ../../common/vars.mk
 
 # https://github.com/containerd/containerd/blob/release/1.6/.github/workflows/release.yml#L9
-export GO_VERSION = 1.19.12
+export GO_VERSION = 1.20.8
 
 DESTDIR ?= $(BASEDIR)/bin
 BAKE_DEFINITIONS ?= -f docker-bake.hcl -f ../../common/packages.hcl

--- a/pkg/containerd/docker-bake.hcl
+++ b/pkg/containerd/docker-bake.hcl
@@ -43,7 +43,7 @@ variable "GO_IMAGE" {
   default = "golang"
 }
 variable "GO_VERSION" {
-  default = "1.19.12"
+  default = "1.20.8"
 }
 variable "GO_IMAGE_VARIANT" {
   default = "bullseye"


### PR DESCRIPTION
Also align go-md2man version with the one from release/1.6 branch.