### PR TITLE
ci(nightly): exclude deprecated packages

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -8,8 +8,12 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 1 * * 0' # every sunday at 1am
+
+env:
+  DISABLED_PACKAGES: scan,sbom
 
 jobs:
   prepare:
@@ -25,7 +29,7 @@ jobs:
         id: projects
         run: |
           projects=$(find ./pkg -maxdepth 1 -type d -printf '%P ')
-          projects=$(echo $projects | jq -cR 'split(" ")')
+          projects=$(echo $projects | jq -cR --arg exclude "${{ env.DISABLED_PACKAGES }}" 'split(" ") | map(select(. | IN($exclude | split(",")) | not))')
           echo "matrix=$projects" >>${GITHUB_OUTPUT}
       -
         name: Show matrix

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ include common/packages.mk
 
 GHA_MATRIX ?= minimal
 ifeq ($(GHA_MATRIX),minimal)
-	GHA_RELEASES := debian10 debian11 debian12 ubuntu2004 ubuntu2204 ubuntu2304 ubuntu2310 centos7 centos9 oraclelinux7 fedora38 fedora39 static
+	GHA_RELEASES := debian10 debian11 debian12 ubuntu2004 ubuntu2204 ubuntu2310 centos7 centos9 oraclelinux7 fedora39 static
 else ifeq ($(GHA_MATRIX),all)
 	GHA_RELEASES := $(PKG_DEB_RELEASES) $(PKG_RPM_RELEASES) static
 else


### PR DESCRIPTION
Exclude `sbom` and `scan` packages from being built in the nightly workflow. Also update minimal GHA matrix.