### PR TITLE
docker-cli, docker-engine: remove outdated "conflicts

### DIFF
--- a/pkg/docker-cli/deb/control
+++ b/pkg/docker-cli/deb/control
@@ -20,7 +20,6 @@ Recommends: docker-buildx-plugin,
             docker-compose-plugin
 Conflicts: docker (<< 1.5~),
            docker-engine,
-           docker-engine-cs,
            docker.io,
            lxc-docker,
            lxc-docker-virtual-package

--- a/pkg/docker-cli/deb/control
+++ b/pkg/docker-cli/deb/control
@@ -20,9 +20,7 @@ Recommends: docker-buildx-plugin,
             docker-compose-plugin
 Conflicts: docker (<< 1.5~),
            docker-engine,
-           docker.io,
-           lxc-docker,
-           lxc-docker-virtual-package
+           docker.io
 Replaces: docker-ce (<< 5:0)
 Breaks: docker-ce (<< 5:0)
 Description: Docker CLI: the open-source application container engine

--- a/pkg/docker-cli/rpm/docker-ce-cli.spec
+++ b/pkg/docker-cli/rpm/docker-ce-cli.spec
@@ -33,7 +33,6 @@ BuildRequires: make
 
 Conflicts: docker
 Conflicts: docker-io
-Conflicts: docker-engine-cs
 Conflicts: docker-ee
 Conflicts: docker-ee-cli
 

--- a/pkg/docker-engine/deb/control
+++ b/pkg/docker-engine/deb/control
@@ -38,7 +38,6 @@ Recommends: apparmor,
 Suggests: aufs-tools [amd64], cgroupfs-mount | cgroup-lite
 Conflicts: docker (<< 1.5~),
            docker-engine,
-           docker-engine-cs,
            docker.io,
            lxc-docker,
            lxc-docker-virtual-package

--- a/pkg/docker-engine/deb/control
+++ b/pkg/docker-engine/deb/control
@@ -38,9 +38,7 @@ Recommends: apparmor,
 Suggests: aufs-tools [amd64], cgroupfs-mount | cgroup-lite
 Conflicts: docker (<< 1.5~),
            docker-engine,
-           docker.io,
-           lxc-docker,
-           lxc-docker-virtual-package
+           docker.io
 Replaces: docker-engine
 Description: Docker: the open-source application container engine
  Docker is a product for you to build, ship and run any application as a

--- a/pkg/docker-engine/rpm/docker-ce.spec
+++ b/pkg/docker-engine/rpm/docker-ce.spec
@@ -57,7 +57,6 @@ BuildRequires: which
 
 Conflicts: docker
 Conflicts: docker-io
-Conflicts: docker-engine-cs
 Conflicts: docker-ee
 
 Obsoletes: docker-ce-selinux


### PR DESCRIPTION
- relates to https://github.com/docker/docker-ce-packaging/pull/1019

### docker-cli, docker-engine: remove "Conflicts: docker-engine-cs"

This was added in [docker@a15b67b1affb2eac5365614e55703f43b6f73e9b] (2015),
at which time this package was already deprecated / replaced:

> Add old docker-engine-cs name to package conflicts

[docker@a15b67b1affb2eac5365614e55703f43b6f73e9b]: https://github.com/moby/moby/commit/a15b67b1affb2eac5365614e55703f43b6f73e9b


### docker-cli, docker-engine:  remove "Conflicts: lxc-docker, lxc-docker-virtual-package"

These conflicts were added as part of the first implementation of the deb
packaging scripts in [docker@eee1efcfd6c46dbdc5da02ca12722e399a56bb12] (2015)
to replace the old packages. These packages where part of the old PPA at
get.docker.io (see [1], [2]), which is long gone;

    curl -I https://get.docker.io/ubuntu
    HTTP/1.1 301 Moved Permanently
    content-length: 0
    location: https://get.docker.com/ubuntu

    curl -fsSL https://get.docker.com/ubuntu
    echo "# WARNING! This script is deprecated. Please use the script"
    echo "# at https://get.docker.com/"
    exit 1

[docker@eee1efcfd6c46dbdc5da02ca12722e399a56bb12]: https://github.com/moby/moby/commit/eee1efcfd6c46dbdc5da02ca12722e399a56bb12
[2]: https://www.ubuntuupdates.org/package/docker/docker/main/base/lxc-docker
[3]: https://www.ubuntuupdates.org/ppa/docker?dist=docker
