### PR TITLE
pkg(compose): fix static build

### DIFF
--- a/pkg/compose/Dockerfile
+++ b/pkg/compose/Dockerfile
@@ -169,7 +169,7 @@ WORKDIR /build
 # download dependencies before "ARG TARGETPLATFORM" otherwise it will be cached
 # for each platform and that would take a lot of disk space
 RUN --mount=type=bind,from=src,source=/src/go.mod,target=/build/go.mod \
-    --mount=type=bind,from=src,source=/src/go.mod,target=/build/go.sum,rw \
+    --mount=type=bind,from=src,source=/src/go.sum,target=/build/go.sum,rw \
     --mount=type=bind,from=gocross,source=/usr/local/go,target=/usr/local/go,rw \
     go mod download -x
 ARG TARGETPLATFORM
@@ -201,7 +201,7 @@ WORKDIR /build
 # download dependencies before "ARG TARGETPLATFORM" otherwise it will be cached
 # for each platform and that would take a lot of disk space
 RUN --mount=type=bind,from=src,source=/src/go.mod,target=/build/go.mod \
-    --mount=type=bind,from=src,source=/src/go.mod,target=/build/go.sum,rw \
+    --mount=type=bind,from=src,source=/src/go.sum,target=/build/go.sum,rw \
     --mount=type=bind,from=gocross,source=/usr/local/go,target=/usr/local/go,rw \
     go mod download -x
 ARG TARGETPLATFORM


### PR DESCRIPTION
relates to https://github.com/docker/packaging/actions/runs/15518277734/job/43688076608#step:8:1245

```
 > [linux/amd64 builder-static-nosdk 5/7] RUN --mount=type=bind,from=src,source=/src/go.mod,target=/build/go.mod     --mount=type=bind,from=src,source=/src/go.mod,target=/build/go.sum,rw     --mount=type=bind,from=gocross,source=/usr/local/go,target=/usr/local/go,rw     go mod download -x:
0.110 # get https://proxy.golang.org/github.com/%21defang%21labs/secret-detector/@v/v0.0.0-20250403165618-22662109213e.mod
0.110 # get https://proxy.golang.org/dario.cat/mergo/@v/v1.0.1.mod
0.110 # get https://proxy.golang.org/github.com/%21alec%21aivazis/survey/v2/@v/v2.3.7.mod
0.110 # get https://proxy.golang.org/github.com/%21azure/go-ansiterm/@v/v0.0.0-20250102033503-faa5f7b0171c.mod
0.181 # get https://proxy.golang.org/dario.cat/mergo/@v/v1.0.1.mod: 200 OK (0.071s)
0.181 # get https://proxy.golang.org/github.com/%21alec%21aivazis/survey/v2/@v/v2.3.7.mod: 200 OK (0.071s)
0.181 malformed go.sum:
0.181 /build/go.sum:1: wrong number of fields 2
```