### PR TITLE
pkg(buildx): use build script directly for static build

### DIFF
--- a/pkg/buildx/scripts/pkg-static-build.sh
+++ b/pkg/buildx/scripts/pkg-static-build.sh
@@ -49,7 +49,7 @@ mkdir -p ${BUILDDIR}/${PKG_NAME}
 (
   set -x
   pushd ${SRCDIR}
-    VERSION=${GENVER_VERSION} REVISION=${GENVER_COMMIT} DESTDIR=/tmp/buildx-build make build
+    VERSION=${GENVER_VERSION} REVISION=${GENVER_COMMIT} DESTDIR=/tmp/buildx-build ./hack/build
     mv "/tmp/buildx-build/docker-buildx" "${BUILDDIR}/${PKG_NAME}/docker-buildx${binext}"
   popd
   xx-verify --static "${BUILDDIR}/${PKG_NAME}/docker-buildx${binext}"


### PR DESCRIPTION
relates to https://github.com/docker/packaging/actions/runs/15518358503/job/43688280889#step:8:703

```
 #35 [linux/amd64->arm64 builder-static 5/5] RUN --mount=type=bind,source=scripts/pkg-static-build.sh,target=/usr/local/bin/pkg-static-build     --mount=type=bind,from=common-scripts,source=gen-ver.sh,target=/usr/local/bin/gen-ver     --mount=type=bind,from=common-scripts,source=fix-cc.sh,target=/usr/local/bin/fix-cc     --mount=type=bind,from=src,source=/src,target=/usr/local/src/buildx     --mount=type=bind,from=gocross,source=/usr/local/go,target=/usr/local/go,rw     OUTDIR=/out BUILDDIR=/build SRCDIR=/usr/local/src/buildx pkg-static-build
#35 0.432 + pushd /usr/local/src/buildx
#35 0.432 + VERSION=v0.0.0-20250606185437-02ab492
#35 0.432 /usr/local/src/buildx /build
#35 0.433 + REVISION=02ab492cac450454a64b648d6bd73556f83210d9
#35 0.433 + DESTDIR=/tmp/buildx-build
#35 0.433 + make build
#35 0.436 make: docker: No such file or directory
```