### PR TITLE
ci(build): fix download artifacts pattern on release

### DIFF
--- a/.github/workflows/.build.yml
+++ b/.github/workflows/.build.yml
@@ -149,19 +149,10 @@ jobs:
 
   release:
     runs-on: ubuntu-24.04
-    timeout-minutes: 20
+    timeout-minutes: 10
     needs:
       - build
     steps:
-      -
-        name: Free disk space
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
-        with:
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          swap-storage: true
       -
         name: Checkout
         uses: actions/checkout@v4
@@ -181,7 +172,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: ./bin/pkg/${{ inputs.name }}
-          pattern: build-pkg-*
+          pattern: build-pkg-${{ inputs.name }}-*
           merge-multiple: true
       -
         name: List artifacts


### PR DESCRIPTION
#215 was not needed actually as there was a bug where it would download artifacts of other packages. This happens only on nightly builds where this workflow builds multiple packages in a matrix.