### PR TITLE
pkg(containerd): update macros used in rpm spec

### DIFF
--- a/pkg/containerd/rpm/containerd.spec
+++ b/pkg/containerd/rpm/containerd.spec
@@ -80,23 +80,23 @@ low-level storage and network attachments, etc.
 
 
 %prep
-rm -rf %{_topdir}/BUILD/
-if [ ! -d %{_topdir}/SOURCES/containerd ]; then
+rm -rf %{_builddir}
+if [ ! -d %{_sourcedir}/containerd ]; then
     # Copy over our source code from our gopath to our source directory
-    cp -rf /go/src/%{import_path} %{_topdir}/SOURCES/containerd;
+    cp -rf /go/src/%{import_path} %{_sourcedir}/containerd;
 fi
 # symlink the go source path to our build directory
-ln -s /go/src/%{import_path} %{_topdir}/BUILD
+ln -s /go/src/%{import_path} %{_builddir}
 
-if [ ! -d %{_topdir}/SOURCES/runc ]; then
+if [ ! -d %{_sourcedir}/runc ]; then
     # Copy over our source code from our gopath to our source directory
-    cp -rf /go/src/github.com/opencontainers/runc %{_topdir}/SOURCES/runc
+    cp -rf /go/src/github.com/opencontainers/runc %{_sourcedir}/runc
 fi
-cd %{_topdir}/BUILD/
+cd %{_builddir}
 
 
 %build
-cd %{_topdir}/BUILD
+cd %{_builddir}
 GO111MODULE=auto make man
 GO111MODULE=auto make -C /go/src/%{import_path} VERSION=%{_origversion} REVISION=%{_commit} PACKAGE=%{getenv:PKG_NAME} BUILDTAGS="%{getenv:BUILDTAGS}"
 
@@ -105,11 +105,11 @@ rm -f bin/containerd-stress
 bin/containerd --version
 bin/ctr --version
 
-GO111MODULE=auto make -C /go/src/github.com/opencontainers/runc BINDIR=%{_topdir}/BUILD/bin runc install
+GO111MODULE=auto make -C /go/src/github.com/opencontainers/runc BINDIR=%{_builddir}/bin runc install
 
 
 %install
-cd %{_topdir}/BUILD
+cd %{_builddir}
 mkdir -p %{buildroot}%{_bindir}
 install -D -m 0755 bin/* %{buildroot}%{_bindir}
 install -D -m 0644 %{S:1} %{buildroot}%{_unitdir}/containerd.service


### PR DESCRIPTION
follow-up:
* https://github.com/docker/containerd-packaging/pull/367

relates to https://github.com/docker/packaging/actions/runs/15822270439/job/44594051089?pr=222#step:7:1794

```
#40 0.299 + rpmbuild --target x86_64 -bb --define '_version 0.0.0~20250622010009~9300d03' --define '_origversion v0.0.0-20250622010009-9300d03' --define '_release 0' --define '_commit 9300d03899283ac9c8a88d451fb12aadb42fd77f' /root/rpmbuild/SPECS/containerd.spec
#40 0.306 Building target platforms: x86_64
#40 0.306 Building for target x86_64
#40 0.309 warning: line 38: It's not recommended to have unversioned Obsoletes: Obsoletes: containerd
#40 0.309 warning: line 39: It's not recommended to have unversioned Obsoletes: Obsoletes: runc
#40 0.322 setting SOURCE_DATE_EPOCH=1675036800
#40 0.332 Executing(%mkbuilddir): /bin/sh -e /var/tmp/rpm-tmp.mOGdP7
#40 0.338 Executing(%prep): /bin/sh -e /var/tmp/rpm-tmp.qQHJdu
#40 0.340 + umask 022
#40 0.340 + cd /root/rpmbuild/BUILD/containerd.io-0.0.0_20250622010009_9300d03-build
#40 0.340 + rm -rf /root/rpmbuild/BUILD/
#40 0.341 + '[' '!' -d /root/rpmbuild/SOURCES/containerd ']'
#40 0.341 + cp -rf /go/src/github.com/containerd/containerd /root/rpmbuild/SOURCES/containerd
#40 0.885 + ln -s /go/src/github.com/containerd/containerd /root/rpmbuild/BUILD
#40 0.887 + '[' '!' -d /root/rpmbuild/SOURCES/runc ']'
#40 0.887 + cp -rf /go/src/github.com/opencontainers/runc /root/rpmbuild/SOURCES/runc
#40 1.009 + cd /root/rpmbuild/BUILD/
#40 1.009 + RPM_EC=0
#40 1.009 ++ jobs -p
#40 1.010 + exit 0
#40 1.012 Executing(%build): /bin/sh -e /var/tmp/rpm-tmp.d7VDfq
#40 1.014 + umask 022
#40 1.014 + cd /root/rpmbuild/BUILD/containerd.io-0.0.0_20250622010009_9300d03-build
#40 1.014 /var/tmp/rpm-tmp.d7VDfq: line 33: cd: /root/rpmbuild/BUILD/containerd.io-0.0.0_20250622010009_9300d03-build: No such file or directory
#40 1.014 
#40 1.014 RPM build warnings:
#40 1.014 error: Bad exit status from /var/tmp/rpm-tmp.d7VDfq (%build)
#40 1.014     line 38: It's not recommended to have unversioned Obsoletes: Obsoletes: containerd
#40 1.014     line 39: It's not recommended to have unversioned Obsoletes: Obsoletes: runc
#40 1.015 
#40 1.015 RPM build errors:
#40 1.015     Bad exit status from /var/tmp/rpm-tmp.d7VDfq (%build)
#40 ERROR: process "/bin/sh -c OUTDIR=/out SRCDIR=/go/src/github.com/containerd/containerd pkg-rpm-build" did not complete successfully: exit code: 1
```