### PR TITLE
pkg(containerd): remove rpm version-constraint for container-selinux

### DIFF
--- a/pkg/containerd/rpm/containerd.spec
+++ b/pkg/containerd/rpm/containerd.spec
@@ -55,7 +55,7 @@ Source3: runc.tgz
 %if %{undefined suse_version}
 # amazonlinux2 doesn't have container-selinux either
 %if "%{?dist}" != ".amzn2"
-Requires: container-selinux >= 2:2.74
+Requires: container-selinux
 %endif
 Requires: libseccomp
 %else
@@ -65,7 +65,6 @@ Requires: libseccomp2
 %endif
 BuildRequires: make
 BuildRequires: gcc
-BuildRequires: libtool-ltdl-devel
 BuildRequires: systemd
 BuildRequires: libseccomp-devel
 


### PR DESCRIPTION
follow-up:
* https://github.com/docker/containerd-packaging/pull/361

Also removes `libtool-ltdl-devel` related to: https://github.com/docker/packaging/actions/runs/15825130078/job/44603303125?pr=226#step:7:1506

```
0.351 Updating Subscription Management repositories.
0.351 Unable to read consumer identity
0.355 
0.355 This system is not registered with an entitlement server. You can use subscription-manager to register.
0.355 
0.400 Last metadata expiration check: 0:00:08 ago on Mon Jun 23 13:10:00 2025.
0.534 No matching package to install: 'libtool-ltdl-devel'
0.534 Package systemd-239-82.el8_10.5.x86_64 is already installed.
0.535 Not all dependencies satisfied
0.546 Error: Some packages could not be found.
```

Not used upstream either: https://github.com/docker/containerd-packaging/blob/2161c611a72887063f4a054aeef4343ebc5ae91f/rpm/containerd.spec#L68-L71