### PR TITLE
Bump containerd.io minimum version to 1.7.27

### DIFF
--- a/pkg/docker-engine/deb/control
+++ b/pkg/docker-engine/deb/control
@@ -19,7 +19,7 @@ Build-Depends: ca-certificates,
 
 Package: docker-ce
 Architecture: linux-any
-Depends: containerd.io (>= 1.6.4),
+Depends: containerd.io (>= 1.7.27),
          docker-ce-cli,
          iptables,
          ${shlibs:Depends}

--- a/pkg/docker-engine/rpm/docker-ce.spec
+++ b/pkg/docker-engine/rpm/docker-ce.spec
@@ -24,7 +24,7 @@ Requires: iptables
 # Libcgroup is no longer available in RHEL/CentOS >= 9 distros.
 Requires: libcgroup
 %endif
-Requires: containerd.io >= 1.6.4
+Requires: containerd.io >= 1.7.27
 Requires: tar
 Requires: xz
 


### PR DESCRIPTION
This change bumps the containerd.io package minimum version to 1.7.27 for docker-engine.