### PR TITLE
deb: use gen-deb-changelog for model and compose

### DIFF
--- a/pkg/compose/scripts/pkg-deb-build.sh
+++ b/pkg/compose/scripts/pkg-deb-build.sh
@@ -54,14 +54,10 @@ for l in $(gen-ver "${SRCDIR}"); do
   export "${l?}"
 done
 
+gen-deb-changelog "$GENVER_VERSION" "$GENVER_PKG_VERSION" "$DISTRO_RELEASE" "$DISTRO_ID" "$DISTRO_SUITE" "$PKG_DEB_REVISION" "$PKG_DEB_EPOCH"
+
 xx-go --wrap
 fix-cc
-
-cat > "debian/changelog" <<-EOF
-${PKG_NAME} (${PKG_DEB_EPOCH}$([ -n "$PKG_DEB_EPOCH" ] && echo ":")${GENVER_PKG_VERSION}-${PKG_DEB_REVISION}) $DISTRO_SUITE; urgency=low
-  * Version: ${GENVER_VERSION}
- -- $(awk -F ': ' '$1 == "Maintainer" { print $2; exit }' debian/control)  $(date --rfc-2822)
-EOF
 
 pkgoutput="${OUTDIR}/${DISTRO_RELEASE}/${DISTRO_SUITE}/$(xx-info arch)"
 if [ -n "$(xx-info variant)" ]; then

--- a/pkg/model/scripts/pkg-deb-build.sh
+++ b/pkg/model/scripts/pkg-deb-build.sh
@@ -54,14 +54,10 @@ for l in $(gen-ver "${SRCDIR}"); do
   export "${l?}"
 done
 
+gen-deb-changelog "$GENVER_VERSION" "$GENVER_PKG_VERSION" "$DISTRO_RELEASE" "$DISTRO_ID" "$DISTRO_SUITE" "$PKG_DEB_REVISION" "$PKG_DEB_EPOCH"
+
 xx-go --wrap
 fix-cc
-
-cat > "debian/changelog" <<-EOF
-${PKG_NAME} (${PKG_DEB_EPOCH}$([ -n "$PKG_DEB_EPOCH" ] && echo ":")${GENVER_PKG_VERSION}-${PKG_DEB_REVISION}) $DISTRO_SUITE; urgency=low
-  * Version: ${GENVER_VERSION}
- -- $(awk -F ': ' '$1 == "Maintainer" { print $2; exit }' debian/control)  $(date --rfc-2822)
-EOF
 
 pkgoutput="${OUTDIR}/${DISTRO_RELEASE}/${DISTRO_SUITE}/$(xx-info arch)"
 if [ -n "$(xx-info variant)" ]; then


### PR DESCRIPTION
Standardize package filename format to include distribution information for docker-model-plugin and docker-compose-plugin packages.

Before this change, model plugin filenames didn't have distro information:

```diff
-docker-model-plugin_0.1.36-0_arm64.deb
+docker-model-plugin_0.1.36-0~debian.12~bookworm_arm64.deb
```