### PR TITLE
gha/build: fix release condition for Docker image push

### DIFF
--- a/.github/workflows/.build.yml
+++ b/.github/workflows/.build.yml
@@ -238,7 +238,7 @@ jobs:
           targets: release-${{ inputs.name }}
           provenance: false
           set: |
-            *.output=type=image,push=${{ inputs.release || github.event_name == 'schedule' }}
+            *.output=type=image,push=${{ inputs.release != '' || github.event_name == 'schedule' }}
             *.output=/tmp/release
       -
         name: List release artifacts


### PR DESCRIPTION
Fix `ERROR: failed to solve: non-bool value specified for push: strconv.ParseBool: parsing "draft": invalid syntax`   

https://github.com/docker/packaging/actions/runs/17164640078/job/48702246917#step:11:407
