### PR TITLE
Add Fedora 43.

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -33,6 +33,7 @@ variable "DISTROS" {
     "centos10",
     "fedora41",
     "fedora42",
+    "fedora43",
     "oraclelinux8",
     "oraclelinux9",
     "rhel8",
@@ -357,6 +358,18 @@ target "_distro-fedora42" {
   }
 }
 
+target "_distro-fedora43" {
+  args = {
+    DISTRO_NAME = "fedora43"
+    DISTRO_TYPE = "rpm"
+    DISTRO_RELEASE = "fedora"
+    DISTRO_ID = "43"
+    DISTRO_SUITE = "43"
+    DISTRO_IMAGE = DISTRO_IMAGE != null && DISTRO_IMAGE != "" ? DISTRO_IMAGE : "fedora:43"
+    TEST_ONLY = "0"
+  }
+}
+
 target "_distro-oraclelinux8" {
   args = {
     DISTRO_NAME = "oraclelinux8"
@@ -457,6 +470,7 @@ function "distroPlatforms" {
         centos10 = ["linux/amd64", "linux/arm64", "linux/ppc64le"]
         fedora41 = ["linux/amd64", "linux/arm64", "linux/ppc64le", "linux/s390x"]
         fedora42 = ["linux/amd64", "linux/arm64", "linux/ppc64le", "linux/s390x"]
+        fedora43 = ["linux/amd64", "linux/arm64", "linux/ppc64le", "linux/s390x"]
         oraclelinux8 = ["linux/amd64", "linux/arm64"]
         oraclelinux9 = ["linux/amd64", "linux/arm64"]
         rhel8 = ["linux/amd64", "linux/arm64", "linux/ppc64le", "linux/s390x"]


### PR DESCRIPTION
This will require first this containerd-packaging pull request to be merged and that an actual fedora 43 rpm for containerd is created before being able to merge this: https://github.com/docker/containerd-packaging/pull/427