### PR TITLE
gha/release: default to pushonly

### DIFF
--- a/.github/workflows/release-buildx.yml
+++ b/.github/workflows/release-buildx.yml
@@ -18,7 +18,7 @@ on:
       release:
         description: 'Release type'
         required: false
-        default: 'prerelease'
+        default: 'pushonly'
         type: choice
         options:
           - pushonly

--- a/.github/workflows/release-compose.yml
+++ b/.github/workflows/release-compose.yml
@@ -18,7 +18,7 @@ on:
       release:
         description: 'Release type'
         required: false
-        default: 'prerelease'
+        default: 'pushonly'
         type: choice
         options:
           - pushonly

--- a/.github/workflows/release-containerd.yml
+++ b/.github/workflows/release-containerd.yml
@@ -18,7 +18,7 @@ on:
       release:
         description: 'Release type'
         required: false
-        default: 'prerelease'
+        default: 'pushonly'
         type: choice
         options:
           - pushonly

--- a/.github/workflows/release-credential-helpers.yml
+++ b/.github/workflows/release-credential-helpers.yml
@@ -18,7 +18,7 @@ on:
       release:
         description: 'Release type'
         required: false
-        default: 'prerelease'
+        default: 'pushonly'
         type: choice
         options:
           - pushonly

--- a/.github/workflows/release-docker-cli.yml
+++ b/.github/workflows/release-docker-cli.yml
@@ -18,7 +18,7 @@ on:
       release:
         description: 'Release type'
         required: false
-        default: 'prerelease'
+        default: 'pushonly'
         type: choice
         options:
           - pushonly

--- a/.github/workflows/release-docker-engine.yml
+++ b/.github/workflows/release-docker-engine.yml
@@ -18,7 +18,7 @@ on:
       release:
         description: 'Release type'
         required: false
-        default: 'prerelease'
+        default: 'pushonly'
         type: choice
         options:
           - pushonly

--- a/.github/workflows/release-model.yml
+++ b/.github/workflows/release-model.yml
@@ -18,7 +18,7 @@ on:
       release:
         description: 'Release type'
         required: false
-        default: 'prerelease'
+        default: 'pushonly'
         type: choice
         options:
           - pushonly


### PR DESCRIPTION
Require an explicit choice to create a Github release