### PR TITLE
gha/build: Support building only single distro

### DIFF
--- a/.github/workflows/.build.yml
+++ b/.github/workflows/.build.yml
@@ -13,6 +13,9 @@ on:
       release:
         required: false
         type: string
+      distro:
+        required: false
+        type: string
 
 env:
   REPO_SLUG: dockereng/packaging
@@ -35,10 +38,12 @@ jobs:
         env:
           INPUT_NAME: ${{ inputs.name }}
           INPUT_RELEASE: ${{ inputs.release }}
+          INPUT_DISTRO: ${{ inputs.distro }}
         with:
           script: |
             const inpName = core.getInput('name');
             const inpRelease = core.getInput('release');
+            const inpDistro = core.getInput('distro');
             
             if (inpRelease !== '' && !['pushonly', 'draft', 'prerelease', 'release'].includes(inpRelease)) {
               throw new Error(`Invalid release type: ${inpRelease}`);
@@ -67,6 +72,10 @@ jobs:
                 }
                 const pkgName = match[1];
                 const distro = match[2];
+                // Skip distros that don't match the input distro filter
+                if (inpDistro !== '' && distro !== inpDistro) {
+                  continue;
+                }
                 const target = def.target[targetName];
                 if (target.platforms && target.platforms.length > 0) {
                   target.platforms.forEach(platform => {

--- a/.github/workflows/release-buildx.yml
+++ b/.github/workflows/release-buildx.yml
@@ -25,6 +25,11 @@ on:
           - draft
           - prerelease
           - release
+      distro:
+        description: 'Single distro to build'
+        required: false
+        type: string
+        default: ''
 
 jobs:
   release:
@@ -32,6 +37,7 @@ jobs:
     with:
       name: buildx
       release: ${{ inputs.release }}
+      distro: ${{ inputs.distro }}
       envs: |
         PKG_REPO=${{ inputs.repo }}
         PKG_REF=${{ inputs.ref }}

--- a/.github/workflows/release-compose.yml
+++ b/.github/workflows/release-compose.yml
@@ -25,6 +25,11 @@ on:
           - draft
           - prerelease
           - release
+      distro:
+        description: 'Single distro to build for'
+        required: false
+        type: string
+        default: ''
 
 jobs:
   release:
@@ -32,6 +37,7 @@ jobs:
     with:
       name: compose
       release: ${{ inputs.release }}
+      distro: ${{ inputs.distro }}
       envs: |
         PKG_REPO=${{ inputs.repo }}
         PKG_REF=${{ inputs.ref }}

--- a/.github/workflows/release-containerd.yml
+++ b/.github/workflows/release-containerd.yml
@@ -25,6 +25,11 @@ on:
           - draft
           - prerelease
           - release
+      distro:
+        description: 'Single distro to build'
+        required: false
+        type: string
+        default: ''
 
 jobs:
   release:
@@ -32,6 +37,7 @@ jobs:
     with:
       name: containerd
       release: ${{ inputs.release }}
+      distro: ${{ inputs.distro }}
       envs: |
         PKG_REPO=${{ inputs.repo }}
         PKG_REF=${{ inputs.ref }}

--- a/.github/workflows/release-credential-helpers.yml
+++ b/.github/workflows/release-credential-helpers.yml
@@ -25,6 +25,11 @@ on:
           - draft
           - prerelease
           - release
+      distro:
+        description: 'Single distro to build'
+        required: false
+        type: string
+        default: ''
 
 jobs:
   release:
@@ -32,6 +37,7 @@ jobs:
     with:
       name: credential-helpers
       release: ${{ inputs.release }}
+      distro: ${{ inputs.distro }}
       envs: |
         PKG_REPO=${{ inputs.repo }}
         PKG_REF=${{ inputs.ref }}

--- a/.github/workflows/release-docker-cli.yml
+++ b/.github/workflows/release-docker-cli.yml
@@ -25,6 +25,11 @@ on:
           - draft
           - prerelease
           - release
+      distro:
+        description: 'Single distro to build'
+        required: false
+        type: string
+        default: ''
 
 jobs:
   release:
@@ -32,6 +37,7 @@ jobs:
     with:
       name: docker-cli
       release: ${{ inputs.release }}
+      distro: ${{ inputs.distro }}
       envs: |
         PKG_REPO=${{ inputs.repo }}
         PKG_REF=${{ inputs.ref }}

--- a/.github/workflows/release-docker-engine.yml
+++ b/.github/workflows/release-docker-engine.yml
@@ -25,6 +25,11 @@ on:
           - draft
           - prerelease
           - release
+      distro:
+        description: 'Single distro to build'
+        required: false
+        type: string
+        default: ''
 
 jobs:
   release:
@@ -32,6 +37,7 @@ jobs:
     with:
       name: docker-engine
       release: ${{ inputs.release }}
+      distro: ${{ inputs.distro }}
       envs: |
         PKG_REPO=${{ inputs.repo }}
         PKG_REF=${{ inputs.ref }}

--- a/.github/workflows/release-model.yml
+++ b/.github/workflows/release-model.yml
@@ -25,6 +25,11 @@ on:
           - draft
           - prerelease
           - release
+      distro:
+        description: 'Single distro to build'
+        required: false
+        type: string
+        default: ''
 
 jobs:
   release:
@@ -32,6 +37,7 @@ jobs:
     with:
       name: model
       release: ${{ inputs.release }}
+      distro: ${{ inputs.distro }}
       envs: |
         PKG_REPO=${{ inputs.repo }}
         PKG_REF=${{ inputs.ref }}


### PR DESCRIPTION
Add optional distro input parameter to all release workflows and the reusable build workflow to allow building packages for a specific distribution only.

This is useful when backfilling packages for a new distro.