### PR TITLE
update go version for compose and credential-helpers pkgs

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -513,7 +513,7 @@ target "_pkg-compose" {
     PKG_NAME = PKG_NAME != null && PKG_NAME != "" ? PKG_NAME : "docker-compose-plugin"
     PKG_REPO = PKG_REPO != null && PKG_REPO != "" ? PKG_REPO : "https://github.com/docker/compose.git"
     PKG_REF = PKG_REF != null && PKG_REF != "" ? PKG_REF : "main"
-    GO_VERSION = GO_VERSION != null && GO_VERSION != "" ? GO_VERSION : "1.23.12" # https://github.com/docker/compose/blob/c2cb0aef6bbbe1afc8c9e81267621655ac90c5f6/Dockerfile#L18
+    GO_VERSION = GO_VERSION != null && GO_VERSION != "" ? GO_VERSION : "1.24.7" # https://github.com/docker/compose/blob/fa081274567ac350f0e5f16abbe51701b320626e/Dockerfile#L18
     GO_IMAGE_VARIANT = GO_IMAGE_VARIANT != null && GO_IMAGE_VARIANT != "" ? GO_IMAGE_VARIANT : "bookworm"
     PKG_DEB_EPOCH = PKG_DEB_EPOCH != null && PKG_DEB_EPOCH != "" ? PKG_DEB_EPOCH : ""
   }
@@ -524,7 +524,7 @@ target "_pkg-containerd" {
     PKG_NAME = PKG_NAME != null && PKG_NAME != "" ? PKG_NAME : "containerd.io"
     PKG_REPO = PKG_REPO != null && PKG_REPO != "" ? PKG_REPO : "https://github.com/containerd/containerd.git"
     PKG_REF = PKG_REF != null && PKG_REF != "" ? PKG_REF : "main"
-    GO_VERSION = GO_VERSION != null && GO_VERSION != "" ? GO_VERSION : "1.24.7" # https://github.com/containerd/containerd/blame/822fb144732946f2a6f7998bfe748ed175674ade/.github/workflows/release.yml#L16
+    GO_VERSION = GO_VERSION != null && GO_VERSION != "" ? GO_VERSION : "1.24.7" # https://github.com/containerd/containerd/blob/2d28d98490f53d78c98faecfc91f9fd54cdbc16e/.github/workflows/release.yml#L16
     GO_IMAGE_VARIANT = GO_IMAGE_VARIANT != null && GO_IMAGE_VARIANT != "" ? GO_IMAGE_VARIANT : "bookworm"
     PKG_DEB_EPOCH = PKG_DEB_EPOCH != null && PKG_DEB_EPOCH != "" ? PKG_DEB_EPOCH : ""
   }
@@ -535,7 +535,7 @@ target "_pkg-credential-helpers" {
     PKG_NAME = PKG_NAME != null && PKG_NAME != "" ? PKG_NAME : "docker-credential-helpers"
     PKG_REPO = PKG_REPO != null && PKG_REPO != "" ? PKG_REPO : "https://github.com/docker/docker-credential-helpers.git"
     PKG_REF = PKG_REF != null && PKG_REF != "" ? PKG_REF : "master"
-    GO_VERSION = GO_VERSION != null && GO_VERSION != "" ? GO_VERSION : "1.23.12" # https://github.com/docker/docker-credential-helpers/blob/f9d3010165b642df37215b1be945552f2c6f0e3b/Dockerfile#L3
+    GO_VERSION = GO_VERSION != null && GO_VERSION != "" ? GO_VERSION : "1.24.7" # https://github.com/docker/docker-credential-helpers/blob/d4602cd9173ff3126de9fa67353efa73598b639b/Dockerfile#L3
     GO_IMAGE_VARIANT = GO_IMAGE_VARIANT != null && GO_IMAGE_VARIANT != "" ? GO_IMAGE_VARIANT : "bookworm"
     PKG_DEB_EPOCH = PKG_DEB_EPOCH != null && PKG_DEB_EPOCH != "" ? PKG_DEB_EPOCH : ""
   }


### PR DESCRIPTION
relates to https://github.com/docker/packaging/actions/runs/18190773894/job/51785266600?pr=258#step:7:1494

```
0.272 GO111MODULE=on go build  -trimpath -tags "e2e" -ldflags "-w -X github.com/docker/compose/v2/internal.Version=v0.0.0-20250930100346-fa08127" -o "./bin/docker-compose" ./cmd
0.279 go: go.mod requires go >= 1.24.7 (running go 1.23.12; GOTOOLCHAIN=local)
0.279 make: *** [Makefile:61: build] Error 1
0.280 error: Bad exit status from /var/tmp/rpm-tmp.Qtklvx (%build)
0.280     Bad exit status from /var/tmp/rpm-tmp.Qtklvx (%build)
0.280 
0.280 
0.280 RPM build errors:
```