### PR TITLE
rpm: use SPDX identifier for License fields

### DIFF
--- a/pkg/buildx/rpm/docker-buildx-plugin.spec
+++ b/pkg/buildx/rpm/docker-buildx-plugin.spec
@@ -7,7 +7,7 @@ Epoch: 0
 Source0: buildx.tgz
 Summary: Docker Buildx plugin for the Docker CLI
 Group: Tools/Docker
-License: ASL 2.0
+License: Apache-2.0
 URL: https://github.com/docker/buildx
 Vendor: Docker
 Packager: Docker <support@docker.com>

--- a/pkg/compose/rpm/docker-compose-plugin.spec
+++ b/pkg/compose/rpm/docker-compose-plugin.spec
@@ -7,7 +7,7 @@ Epoch: 0
 Source0: compose.tgz
 Summary: Docker Compose plugin for the Docker CLI
 Group: Tools/Docker
-License: ASL 2.0
+License: Apache-2.0
 URL: https://github.com/docker/compose
 Vendor: Docker
 Packager: Docker <support@docker.com>

--- a/pkg/containerd/rpm/containerd.spec
+++ b/pkg/containerd/rpm/containerd.spec
@@ -45,7 +45,7 @@ Conflicts: runc
 Version: %{_version}
 Release: %{_release}%{?dist}
 Summary: An industry-standard container runtime
-License: ASL 2.0
+License: Apache-2.0
 URL: https://containerd.io
 Source0: containerd.tgz
 Source1: containerd.service

--- a/pkg/credential-helpers/rpm/docker-credential-pass.spec
+++ b/pkg/credential-helpers/rpm/docker-credential-pass.spec
@@ -7,7 +7,7 @@ Epoch: 0
 Source0: docker-credential-helpers.tgz
 Summary: Credential helper backend which uses the pass utility to keep Docker credentials safe
 Group: Tools/Docker
-License: ASL 2.0
+License: Apache-2.0
 URL: https://github.com/docker/docker-credential-helpers
 Vendor: Docker
 Packager: Docker <support@docker.com>

--- a/pkg/credential-helpers/rpm/docker-credential-secretservice.spec
+++ b/pkg/credential-helpers/rpm/docker-credential-secretservice.spec
@@ -7,7 +7,7 @@ Epoch: 0
 Source0: docker-credential-helpers.tgz
 Summary: Credential helper backend which uses libsecret to keep Docker credentials safe
 Group: Tools/Docker
-License: ASL 2.0
+License: Apache-2.0
 URL: https://github.com/docker/docker-credential-helpers
 Vendor: Docker
 Packager: Docker <support@docker.com>

--- a/pkg/docker-cli/rpm/docker-ce-cli.spec
+++ b/pkg/docker-cli/rpm/docker-ce-cli.spec
@@ -7,7 +7,7 @@ Epoch: 1
 Source0: cli.tgz
 Summary: The open-source application container engine
 Group: Tools/Docker
-License: ASL 2.0
+License: Apache-2.0
 URL: https://github.com/docker/cli
 Vendor: Docker
 Packager: Docker <support@docker.com>

--- a/pkg/docker-engine/rpm/docker-ce-rootless-extras.spec
+++ b/pkg/docker-engine/rpm/docker-ce-rootless-extras.spec
@@ -7,7 +7,7 @@ Epoch: 0
 Source0: engine.tgz
 Summary: Rootless support for Docker
 Group: Tools/Docker
-License: ASL 2.0
+License: Apache-2.0
 URL: https://docs.docker.com/engine/security/rootless/
 Vendor: Docker
 Packager: Docker <support@docker.com>

--- a/pkg/docker-engine/rpm/docker-ce.spec
+++ b/pkg/docker-engine/rpm/docker-ce.spec
@@ -9,7 +9,7 @@ Source1: docker.service
 Source2: docker.socket
 Summary: The open-source application container engine
 Group: Tools/Docker
-License: ASL 2.0
+License: Apache-2.0
 URL: https://www.docker.com
 Vendor: Docker
 Packager: Docker <support@docker.com>

--- a/pkg/model/rpm/docker-model-plugin.spec
+++ b/pkg/model/rpm/docker-model-plugin.spec
@@ -7,7 +7,7 @@ Epoch: 0
 Source0: model.tgz
 Summary: Docker Model Runner plugin for the Docker CLI
 Group: Tools/Docker
-License: ASL 2.0
+License: Apache-2.0
 URL: https://docs.docker.com/model-runner/
 Vendor: Docker
 Packager: Docker <support@docker.com>


### PR DESCRIPTION
ported from: https://github.com/docker/docker-ce-packaging/pull/1135

Update the license fields to use the (now recommented) SPDX identifier;

> https://docs.fedoraproject.org/en-US/legal/allowed-licenses/ lists
> Apache-2.0 as the SPDX identifier and ASL 2.0 as a "Legacy Abbreviation"
> for Apache License 2.0.