### PR TITLE
bake: Default PKG_DEB_REVISION to 1

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -109,7 +109,7 @@ variable "PKG_DEB_BUILDFLAGS" {
 }
 variable "PKG_DEB_REVISION" {
   description = "Revision of the package to build, used for debian packages. Include an extra .0 in the version, in case we ever would have to re-build an already published release with a packaging-only change."
-  default = "0"
+  default = "1"
 }
 variable "PKG_DEB_EPOCH" {
   description = "Epoch of the package to build, used for debian packages. This is used to allow mistakes in the version numbers of older versions of a package, and also a package's previous version numbering schemes, to be left behind. Should be enforced per package and not globally."


### PR DESCRIPTION
> It is conventional to restart the `debian_revision` at 1 each time the
`upstream_version` is increased.

ref: https://www.debian.org/doc/debian-policy/ch-controlfields.html