### PR TITLE
ci: remove duplicated tags in GitHub release body

### DIFF
--- a/.github/workflows/.build.yml
+++ b/.github/workflows/.build.yml
@@ -273,19 +273,16 @@ jobs:
           ${{ steps.build.outputs.metadata }}
           EOF
           
+          for tag in $(jq -r '.tags[]' <<< "$DOCKER_METADATA_OUTPUT_JSON"); do
+            echo "* \`${tag}\`" >> /tmp/tags.txt
+          done
+          
           cat > "/tmp/summary.txt" <<-EOF
           * repo: ${REPO}
           * ref: \`${REF}\`
           * version: \`${VERSION}\`
           * commit: [\`${COMMIT}\`](${REPO}/commit/${COMMIT})
           EOF
-
-          for tag in $(jq -r '.tags[]' <<< "$DOCKER_METADATA_OUTPUT_JSON"); do
-            echo "* \`${tag}\`" >> /tmp/tags.txt
-          done
-
-          echo "* Tags" >> /tmp/summary.txt
-          sed 's/^/  /' /tmp/tags.txt >> /tmp/summary.txt
 
           if [ "${{ inputs.name }}" = "containerd" ]; then
             cat >> "/tmp/summary.txt" <<-EOF
@@ -306,8 +303,16 @@ jobs:
           * packages: \`$(find /tmp/release -type f | wc -l)\` files
           * size: \`$(du -sh /tmp/release | awk '{print $1}')\`
           EOF
-
-          cat /tmp/summary.txt >> $GITHUB_STEP_SUMMARY
+          
+          cat >> "$GITHUB_STEP_SUMMARY" <<-EOF
+          # Package build
+          
+          ## Tags
+          $(cat /tmp/tags.txt)
+          
+          ## Summary
+          $(cat /tmp/summary.txt)
+          EOF
       -
         name: Set outputs
         uses: actions/github-script@v8


### PR DESCRIPTION
Tags are currently specified twice in GitHub release body: https://github.com/docker/packaging/releases/tag/compose%2Fv2.40.0-34

GH summary will look like this: https://github.com/docker/packaging/actions/runs/18280783450?pr=286#summary-52043561603

<img width="592" height="600" alt="image" src="https://github.com/user-attachments/assets/09190449-7c6f-4f46-88db-f3566a79afb1" />
