### PR TITLE
pkg(deb): add Raspbian Trixie and switch base image

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -22,6 +22,7 @@ variable "DISTROS" {
     "debian13",
     "raspbian11",
     "raspbian12",
+    "raspbian13",
     "ubuntu2204",
     "ubuntu2404",
     "ubuntu2504",
@@ -221,7 +222,7 @@ target "_distro-raspbian11" {
     DISTRO_RELEASE = "raspbian"
     DISTRO_ID = "11"
     DISTRO_SUITE = "bullseye"
-    DISTRO_IMAGE = DISTRO_IMAGE != null && DISTRO_IMAGE != "" ? DISTRO_IMAGE : "balenalib/rpi-raspbian:bullseye"
+    DISTRO_IMAGE = DISTRO_IMAGE != null && DISTRO_IMAGE != "" ? DISTRO_IMAGE : "tianon/raspbian:bullseye"
     TEST_ONLY = "0"
   }
 }
@@ -233,7 +234,19 @@ target "_distro-raspbian12" {
     DISTRO_RELEASE = "raspbian"
     DISTRO_ID = "12"
     DISTRO_SUITE = "bookworm"
-    DISTRO_IMAGE = DISTRO_IMAGE != null && DISTRO_IMAGE != "" ? DISTRO_IMAGE : "balenalib/rpi-raspbian:bookworm"
+    DISTRO_IMAGE = DISTRO_IMAGE != null && DISTRO_IMAGE != "" ? DISTRO_IMAGE : "tianon/raspbian:bookworm"
+    TEST_ONLY = "0"
+  }
+}
+
+target "_distro-raspbian13" {
+  args = {
+    DISTRO_NAME = "raspbian13"
+    DISTRO_TYPE = "deb"
+    DISTRO_RELEASE = "raspbian"
+    DISTRO_ID = "13"
+    DISTRO_SUITE = "trixie"
+    DISTRO_IMAGE = DISTRO_IMAGE != null && DISTRO_IMAGE != "" ? DISTRO_IMAGE : "tianon/raspbian:trixie"
     TEST_ONLY = "0"
   }
 }
@@ -457,8 +470,9 @@ function "distroPlatforms" {
         debian11 = ["linux/386", "linux/amd64", "linux/arm64", "linux/arm/v7", "linux/mips64le", "linux/ppc64le", "linux/s390x"]
         debian12 = ["linux/386", "linux/amd64", "linux/arm64", "linux/arm/v7", "linux/mips64le", "linux/ppc64le", "linux/s390x"]
         debian13 = ["linux/386", "linux/amd64", "linux/arm64", "linux/arm/v7", "linux/mips64le", "linux/ppc64le", "linux/riscv64", "linux/s390x"]
-        raspbian11 = ["linux/arm/v7"]
-        raspbian12 = ["linux/arm/v7"]
+        raspbian11 = ["linux/arm/v6", "linux/arm/v7"]
+        raspbian12 = ["linux/arm/v6", "linux/arm/v7"]
+        raspbian13 = ["linux/arm/v6", "linux/arm/v7"]
         ubuntu2204 = ["linux/amd64", "linux/arm64", "linux/arm/v7", "linux/ppc64le", "linux/s390x"]
         ubuntu2404 = ["linux/amd64", "linux/arm64", "linux/arm/v7", "linux/ppc64le", "linux/riscv64", "linux/s390x"]
         ubuntu2504 = ["linux/amd64", "linux/arm64", "linux/arm/v7", "linux/ppc64le", "linux/riscv64", "linux/s390x"]


### PR DESCRIPTION
[balenalib/rpi-raspbian](https://hub.docker.com/r/balenalib/rpi-raspbian) has been archived and not been updated since 2 years. The most downloaded Raspbian base container which provides Debian Trixie images and regular updates at time of writing is from [tianon](https://hub.docker.com/r/tianon/raspbian/tags), which I hope is trustworthy enough. Now that Raspberry Pi OS Trixie has been released, a related Docker APT repository suite would help to address some of its limitations.

Not sure about the impact, but for completeness, `linux/arm/v6` has been added to the compatible architectures of the Raspbian packages, which is the whole point of why Raspbian exists.