### PR TITLE
rootless-extras: add passt as an alternative to slirp4netns

### DIFF
--- a/pkg/docker-engine/deb/control
+++ b/pkg/docker-engine/deb/control
@@ -58,12 +58,12 @@ Conflicts: rootlesskit
 Replaces: rootlesskit
 Breaks: rootlesskit
 # slirp4netns (>= 0.4.0) is available in Debian since 11 and Ubuntu since 19.10
-Recommends: slirp4netns (>= 0.4.0)
+Recommends: slirp4netns (>= 0.4.0) | passt
 # Unlike RPM, DEB packages do not contain "Recommends: fuse-overlayfs (>= 0.7.0)" here,
 # because Debian (since 10) and Ubuntu support the kernel-mode rootless overlayfs.
 Description: Rootless support for Docker.
   Use dockerd-rootless.sh to run the daemon.
   Use dockerd-rootless-setuptool.sh to setup systemd for dockerd-rootless.sh .
   This package contains RootlessKit, but does not contain VPNKit.
-  Either VPNKit or slirp4netns (>= 0.4.0) needs to be installed separately.
+  Either slirp4netns (>= 0.4.0), passt, or VPNKit needs to be installed separately.
 Homepage: https://docs.docker.com/engine/security/rootless/

--- a/pkg/docker-engine/rpm/docker-ce-rootless-extras.spec
+++ b/pkg/docker-engine/rpm/docker-ce-rootless-extras.spec
@@ -15,7 +15,7 @@ Packager: Docker <support@docker.com>
 Requires: docker-ce
 # TODO: conditionally add `Requires: dbus-daemon` for Fedora and CentOS 8
 # slirp4netns >= 0.4 is available in the all supported versions of CentOS and Fedora.
-Requires: slirp4netns >= 0.4
+Requires: (slirp4netns >= 0.4 or passt)
 # fuse-overlayfs >= 0.7 is available in the all supported versions of CentOS and Fedora.
 Requires: fuse-overlayfs >= 0.7
 
@@ -29,7 +29,7 @@ Rootless support for Docker.
 Use dockerd-rootless.sh to run the daemon.
 Use dockerd-rootless-setuptool.sh to setup systemd for dockerd-rootless.sh .
 This package contains RootlessKit, but does not contain VPNKit.
-Either VPNKit or slirp4netns (>= 0.4.0) needs to be installed separately.
+Either slirp4netns (>= 0.4.0), passt, or VPNKit needs to be installed separately.
 
 %prep
 %setup -q -c -n src -a 0


### PR DESCRIPTION
**- What I did**

- related to https://github.com/moby/moby/issues/51143
- related to https://github.com/docker/docker-ce-packaging/pull/1276

In deb/rpm specs - recommend/require `passt` as an alternative to `slirp4netns`. (RHEL 10 deprecates `slirp4netns`.)

**- Description for the changelog**
```markdown changelog
- docker-ce-rootless-extras now depends on `passt` as an alternative to `slirp4netns`.
```
