### PR TITLE
ci: fix nightly builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -42,7 +42,7 @@ jobs:
         pkg: ${{ fromJson(needs.prepare.outputs.pkgs) }}
     with:
       name: ${{ matrix.pkg }}
-      push: true
+      release: pushonly
       envs: |
         NIGHTLY_BUILD=1
     secrets: inherit


### PR DESCRIPTION
relates to https://github.com/docker/packaging/actions/runs/19398410476

```
Invalid workflow file: .github/workflows/nightly.yml#L45
The workflow is not valid. .github/workflows/nightly.yml (Line: 45, Col: 13): Invalid input, push is not defined in the referenced workflow.
```