### PR TITLE
pkg(cagent): update go to 1.25.4

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -600,7 +600,7 @@ target "_pkg-cagent" {
     PKG_NAME = PKG_NAME != null && PKG_NAME != "" ? PKG_NAME : "cagent"
     PKG_REPO = PKG_REPO != null && PKG_REPO != "" ? PKG_REPO : "https://github.com/docker/cagent.git"
     PKG_REF = PKG_REF != null && PKG_REF != "" ? PKG_REF : "main"
-    GO_VERSION = GO_VERSION != null && GO_VERSION != "" ? GO_VERSION : "1.25.3" # https://github.com/docker/cagent/blob/26330cc0e1579ab91fd24a3459986256680d8330/Dockerfile#L6
+    GO_VERSION = GO_VERSION != null && GO_VERSION != "" ? GO_VERSION : "1.25.4" # https://github.com/docker/cagent/blob/259774ed55b2b51c4b602d9636d68a6bb23117ec/Dockerfile#L6
     GO_IMAGE_VARIANT = GO_IMAGE_VARIANT != null && GO_IMAGE_VARIANT != "" ? GO_IMAGE_VARIANT : "bookworm"
     PKG_DEB_EPOCH = PKG_DEB_EPOCH != null && PKG_DEB_EPOCH != "" ? PKG_DEB_EPOCH : ""
   }

--- a/pkg/cagent/Dockerfile
+++ b/pkg/cagent/Dockerfile
@@ -29,7 +29,7 @@ ARG PKG_REPO="https://github.com/docker/cagent.git"
 ARG PKG_REF="master"
 
 ARG GO_IMAGE="golang"
-ARG GO_VERSION="1.25.3"
+ARG GO_VERSION="1.25.4"
 ARG GO_IMAGE_VARIANT="bookworm"
 
 # stage used as named context that mounts hack/scripts


### PR DESCRIPTION
relates to https://github.com/docker/packaging/actions/runs/19640848065/job/56243606401#step:7:1260

```
0.292 + go build -trimpath '-ldflags=-w -X github.com/docker/cagent/pkg/version.Version=v0.0.0-20251124141232-c519da0 -X github.com/docker/cagent/pkg/version.Commit=c519da0065472798b82d09bdea2c350af83a8cca' -o bin/cagent .
0.297 go: go.mod requires go >= 1.25.4 (running go 1.25.3; GOTOOLCHAIN=local)
0.298 error: Bad exit status from /var/tmp/rpm-tmp.msB4TN (%build)
0.298     Bad exit status from /var/tmp/rpm-tmp.msB4TN (%build)
```