### PR TITLE
Drop Raspbian support

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -20,8 +20,6 @@ variable "DISTROS" {
     "debian11",
     "debian12",
     "debian13",
-    "raspbian11",
-    "raspbian12",
     "ubuntu2204",
     "ubuntu2404",
     "ubuntu2510",
@@ -218,30 +216,6 @@ target "_distro-debian13" {
     DISTRO_ID = "13"
     DISTRO_SUITE = "trixie"
     DISTRO_IMAGE = DISTRO_IMAGE != null && DISTRO_IMAGE != "" ? DISTRO_IMAGE : "debian:trixie"
-    TEST_ONLY = "0"
-  }
-}
-
-target "_distro-raspbian11" {
-  args = {
-    DISTRO_NAME = "raspbian11"
-    DISTRO_TYPE = "deb"
-    DISTRO_RELEASE = "raspbian"
-    DISTRO_ID = "11"
-    DISTRO_SUITE = "bullseye"
-    DISTRO_IMAGE = DISTRO_IMAGE != null && DISTRO_IMAGE != "" ? DISTRO_IMAGE : "balenalib/rpi-raspbian:bullseye"
-    TEST_ONLY = "0"
-  }
-}
-
-target "_distro-raspbian12" {
-  args = {
-    DISTRO_NAME = "raspbian12"
-    DISTRO_TYPE = "deb"
-    DISTRO_RELEASE = "raspbian"
-    DISTRO_ID = "12"
-    DISTRO_SUITE = "bookworm"
-    DISTRO_IMAGE = DISTRO_IMAGE != null && DISTRO_IMAGE != "" ? DISTRO_IMAGE : "balenalib/rpi-raspbian:bookworm"
     TEST_ONLY = "0"
   }
 }
@@ -489,8 +463,6 @@ function "distroPlatforms" {
         debian11 = ["linux/386", "linux/amd64", "linux/arm64", "linux/arm/v7", "linux/mips64le", "linux/ppc64le", "linux/s390x"]
         debian12 = ["linux/386", "linux/amd64", "linux/arm64", "linux/arm/v7", "linux/mips64le", "linux/ppc64le", "linux/s390x"]
         debian13 = ["linux/386", "linux/amd64", "linux/arm64", "linux/arm/v7", "linux/mips64le", "linux/ppc64le", "linux/riscv64", "linux/s390x"]
-        raspbian11 = ["linux/arm/v7"]
-        raspbian12 = ["linux/arm/v7"]
         ubuntu2204 = ["linux/amd64", "linux/arm64", "linux/arm/v7", "linux/ppc64le", "linux/s390x"]
         ubuntu2404 = ["linux/amd64", "linux/arm64", "linux/arm/v7", "linux/ppc64le", "linux/riscv64", "linux/s390x"]
         ubuntu2510 = ["linux/amd64", "linux/arm64", "linux/arm/v7", "linux/ppc64le", "linux/riscv64", "linux/s390x"]

--- a/pkg/buildx/deb/rules
+++ b/pkg/buildx/deb/rules
@@ -1,12 +1,5 @@
 #!/usr/bin/make -f
 
-# Build Raspbian armhf binaries as ARMv6 with hard float.
-include /usr/share/dpkg/vendor.mk
-ifeq ($(DEB_VENDOR),Raspbian)
-	export CFLAGS += -marm -march=armv6+fp
-	export GOARM := 6
-endif
-
 # force packages to be built with xz compression, as Ubuntu 21.10 and up use
 # zstd compression, which is non-standard, and breaks 'dpkg-sig --verify'
 override_dh_builddeb:

--- a/pkg/cagent/deb/rules
+++ b/pkg/cagent/deb/rules
@@ -1,12 +1,5 @@
 #!/usr/bin/make -f
 
-# Build Raspbian armhf binaries as ARMv6 with hard float.
-include /usr/share/dpkg/vendor.mk
-ifeq ($(DEB_VENDOR),Raspbian)
-	export CFLAGS += -marm -march=armv6+fp
-	export GOARM := 6
-endif
-
 # force packages to be built with xz compression, as Ubuntu 21.10 and up use
 # zstd compression, which is non-standard, and breaks 'dpkg-sig --verify'
 override_dh_builddeb:

--- a/pkg/compose/deb/rules
+++ b/pkg/compose/deb/rules
@@ -1,12 +1,5 @@
 #!/usr/bin/make -f
 
-# Build Raspbian armhf binaries as ARMv6 with hard float.
-include /usr/share/dpkg/vendor.mk
-ifeq ($(DEB_VENDOR),Raspbian)
-	export CFLAGS += -marm -march=armv6+fp
-	export GOARM := 6
-endif
-
 # force packages to be built with xz compression, as Ubuntu 21.10 and up use
 # zstd compression, which is non-standard, and breaks 'dpkg-sig --verify'
 override_dh_builddeb:

--- a/pkg/containerd/deb/rules
+++ b/pkg/containerd/deb/rules
@@ -14,13 +14,6 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-# Build Raspbian armhf binaries as ARMv6 with hard float.
-include /usr/share/dpkg/vendor.mk
-ifeq ($(DEB_VENDOR),Raspbian)
-	export CFLAGS += -marm -march=armv6+fp
-	export GOARM := 6
-endif
-
 %:
 	dh $@
 

--- a/pkg/credential-helpers/deb/rules
+++ b/pkg/credential-helpers/deb/rules
@@ -1,12 +1,5 @@
 #!/usr/bin/make -f
 
-# Build Raspbian armhf binaries as ARMv6 with hard float.
-include /usr/share/dpkg/vendor.mk
-ifeq ($(DEB_VENDOR),Raspbian)
-	export CFLAGS += -marm -march=armv6+fp
-	export GOARM := 6
-endif
-
 # force packages to be built with xz compression, as Ubuntu 21.10 and up use
 # zstd compression, which is non-standard, and breaks 'dpkg-sig --verify'
 override_dh_builddeb:

--- a/pkg/docker-cli/deb/rules
+++ b/pkg/docker-cli/deb/rules
@@ -1,12 +1,5 @@
 #!/usr/bin/make -f
 
-# Build Raspbian armhf binaries as ARMv6 with hard float.
-include /usr/share/dpkg/vendor.mk
-ifeq ($(DEB_VENDOR),Raspbian)
-	export CFLAGS += -marm -march=armv6+fp
-	export GOARM := 6
-endif
-
 # force packages to be built with xz compression, as Ubuntu 21.10 and up use
 # zstd compression, which is non-standard, and breaks 'dpkg-sig --verify'
 override_dh_builddeb:

--- a/pkg/docker-engine/deb/rules
+++ b/pkg/docker-engine/deb/rules
@@ -1,12 +1,5 @@
 #!/usr/bin/make -f
 
-# Build Raspbian armhf binaries as ARMv6 with hard float.
-include /usr/share/dpkg/vendor.mk
-ifeq ($(DEB_VENDOR),Raspbian)
-	export CFLAGS += -marm -march=armv6+fp
-	export GOARM := 6
-endif
-
 # force packages to be built with xz compression, as Ubuntu 21.10 and up use
 # zstd compression, which is non-standard, and breaks 'dpkg-sig --verify'
 override_dh_builddeb:

--- a/pkg/model/deb/rules
+++ b/pkg/model/deb/rules
@@ -1,12 +1,5 @@
 #!/usr/bin/make -f
 
-# Build Raspbian armhf binaries as ARMv6 with hard float.
-include /usr/share/dpkg/vendor.mk
-ifeq ($(DEB_VENDOR),Raspbian)
-	export CFLAGS += -marm -march=armv6+fp
-	export GOARM := 6
-endif
-
 # force packages to be built with xz compression, as Ubuntu 21.10 and up use
 # zstd compression, which is non-standard, and breaks 'dpkg-sig --verify'
 override_dh_builddeb:


### PR DESCRIPTION
Docker Engine v28 was the last one to package Raspbian (32 bit).

Raspberry Pi is still supported with Debian packages.