### PR TITLE
docker-engine: add nri_no_wasm build tag

### DIFF
--- a/pkg/docker-engine/Dockerfile
+++ b/pkg/docker-engine/Dockerfile
@@ -92,7 +92,7 @@ ENV GOPROXY="https://proxy.golang.org|direct"
 ENV GOPATH="/go"
 ENV GOTOOLCHAIN="local"
 ENV PATH="$PATH:/usr/local/go/bin:$GOPATH/bin"
-ENV DOCKER_BUILDTAGS="apparmor seccomp selinux"
+ENV DOCKER_BUILDTAGS="apparmor seccomp selinux nri_no_wasm"
 ENV RUNC_BUILDTAGS="apparmor seccomp selinux"
 ARG DISTRO_NAME
 RUN apt-get update && apt-get install -y --no-install-recommends apt-utils bash ca-certificates curl devscripts equivs git


### PR DESCRIPTION
This change adds the `nri_no_wasm` build tag for docker engine builds.\ Reference: https://github.com/containerd/nri/blob/1078130fa016884b4c03880d9d587e6691a67d98/README.md#webassembly-support