### PR TITLE
rootless: drop dependency on fuse-overlayfs

### DIFF
--- a/pkg/docker-engine/deb/control
+++ b/pkg/docker-engine/deb/control
@@ -59,8 +59,6 @@ Replaces: rootlesskit
 Breaks: rootlesskit
 # slirp4netns (>= 0.4.0) is available in Debian since 11 and Ubuntu since 19.10
 Recommends: slirp4netns (>= 0.4.0) | passt
-# Unlike RPM, DEB packages do not contain "Recommends: fuse-overlayfs (>= 0.7.0)" here,
-# because Debian (since 10) and Ubuntu support the kernel-mode rootless overlayfs.
 Description: Rootless support for Docker.
   Use dockerd-rootless.sh to run the daemon.
   Use dockerd-rootless-setuptool.sh to setup systemd for dockerd-rootless.sh .

--- a/pkg/docker-engine/rpm/docker-ce-rootless-extras.spec
+++ b/pkg/docker-engine/rpm/docker-ce-rootless-extras.spec
@@ -16,8 +16,6 @@ Requires: docker-ce
 # TODO: conditionally add `Requires: dbus-daemon` for Fedora and CentOS 8
 # slirp4netns >= 0.4 is available in the all supported versions of CentOS and Fedora.
 Requires: (slirp4netns >= 0.4 or passt)
-# fuse-overlayfs >= 0.7 is available in the all supported versions of CentOS and Fedora.
-Requires: fuse-overlayfs >= 0.7
 
 BuildRequires: bash
 


### PR DESCRIPTION
Cherry-pick:
- https://github.com/docker/docker-ce-packaging/pull/1309