### PR TITLE
containerd: Switch to 1.25.9

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -517,8 +517,8 @@ target "_pkg-containerd" {
   args = {
     PKG_NAME = PKG_NAME != null && PKG_NAME != "" ? PKG_NAME : "containerd.io"
     PKG_REPO = PKG_REPO != null && PKG_REPO != "" ? PKG_REPO : "https://github.com/containerd/containerd.git"
-    PKG_REF = PKG_REF != null && PKG_REF != "" ? PKG_REF : "main"
-    GO_VERSION = GO_VERSION != null && GO_VERSION != "" ? GO_VERSION : "1.26.2" # https://github.com/containerd/containerd/blob/main/.github/workflows/release/Dockerfile
+    PKG_REF = PKG_REF != null && PKG_REF != "" ? PKG_REF : "release/2.2"
+    GO_VERSION = GO_VERSION != null && GO_VERSION != "" ? GO_VERSION : "1.25.9" # https://github.com/containerd/containerd/blob/release/2.2/.github/workflows/release/Dockerfile
     GO_IMAGE_VARIANT = GO_IMAGE_VARIANT != null && GO_IMAGE_VARIANT != "" ? GO_IMAGE_VARIANT : "bookworm"
     PKG_DEB_EPOCH = PKG_DEB_EPOCH != null && PKG_DEB_EPOCH != "" ? PKG_DEB_EPOCH : ""
     RUNC_REF = RUNC_REF != null && RUNC_REF != "" ? RUNC_REF : null


### PR DESCRIPTION
1.26 comes from the main branch but the last release (2.2.3) is still on Go 1.25.

For a follow up:
- adjust the automatic bump to pick the latest stable release as source
- allow overriding go version in build workflow?