### PR TITLE
rootless: drop dependency on slirp4netns|vpnkit|pasta

### DIFF
--- a/pkg/docker-engine/deb/control
+++ b/pkg/docker-engine/deb/control
@@ -57,11 +57,7 @@ Enhances: docker-ce
 Conflicts: rootlesskit
 Replaces: rootlesskit
 Breaks: rootlesskit
-# slirp4netns (>= 0.4.0) is available in Debian since 11 and Ubuntu since 19.10
-Recommends: slirp4netns (>= 0.4.0) | passt
 Description: Rootless support for Docker.
   Use dockerd-rootless.sh to run the daemon.
   Use dockerd-rootless-setuptool.sh to setup systemd for dockerd-rootless.sh .
-  This package contains RootlessKit, but does not contain VPNKit.
-  Either slirp4netns (>= 0.4.0), passt, or VPNKit needs to be installed separately.
 Homepage: https://docs.docker.com/engine/security/rootless/

--- a/pkg/docker-engine/deb/rules
+++ b/pkg/docker-engine/deb/rules
@@ -36,7 +36,6 @@ override_dh_auto_install:
 	install -D -p -m 0755 /usr/local/bin/rootlesskit debian/docker-ce-rootless-extras/usr/bin/rootlesskit
 	install -D -p -m 0755 engine/contrib/dockerd-rootless.sh debian/docker-ce-rootless-extras/usr/bin/dockerd-rootless.sh
 	install -D -p -m 0755 engine/contrib/dockerd-rootless-setuptool.sh debian/docker-ce-rootless-extras/usr/bin/dockerd-rootless-setuptool.sh
-	# TODO: how can we install vpnkit?
 
 override_dh_installinit:
 	# use "docker" as our service name, not "docker-ce"

--- a/pkg/docker-engine/rpm/docker-ce-rootless-extras.spec
+++ b/pkg/docker-engine/rpm/docker-ce-rootless-extras.spec
@@ -14,8 +14,6 @@ Packager: Docker <support@docker.com>
 
 Requires: docker-ce
 # TODO: conditionally add `Requires: dbus-daemon` for Fedora and CentOS 8
-# slirp4netns >= 0.4 is available in the all supported versions of CentOS and Fedora.
-Requires: (slirp4netns >= 0.4 or passt)
 
 BuildRequires: bash
 
@@ -26,8 +24,6 @@ Conflicts: rootlesskit
 Rootless support for Docker.
 Use dockerd-rootless.sh to run the daemon.
 Use dockerd-rootless-setuptool.sh to setup systemd for dockerd-rootless.sh .
-This package contains RootlessKit, but does not contain VPNKit.
-Either slirp4netns (>= 0.4.0), passt, or VPNKit needs to be installed separately.
 
 %prep
 %setup -q -c -n src -a 0


### PR DESCRIPTION
RootlessKit v3.0 no longer requires an external program for networking. 
See:
- moby/moby#52319


Cherry-pick:
- https://github.com/docker/docker-ce-packaging/pull/1308