### PR TITLE
rpm: avoid broken rpmlint dependency on EL10 derivatives

### DIFF
--- a/hack/scripts/rpm-init.sh
+++ b/hack/scripts/rpm-init.sh
@@ -74,6 +74,12 @@ case "$pkgrelease" in
     dnf install -y git rpm-build rpmlint dnf-plugins-core epel-release
     dnf config-manager --set-enabled powertools
     ;;
+  rockylinux10|almalinux10)
+    dnf install -y dnf-plugins-core epel-release
+    dnf config-manager --set-enabled crb
+    # skipping rpmlint until EPEL provides its EL10 dependencies
+    dnf install -y git rpm-build
+    ;;
   rockylinux*|almalinux*)
     dnf install -y dnf-plugins-core epel-release
     dnf config-manager --set-enabled crb


### PR DESCRIPTION
AlmaLinux 10 and Rocky Linux 10 currently resolve rpmlint from EPEL to a package that depends on python3.12dist(zstandard), which is not available in the configured repositories.

unblock compose release: https://github.com/docker/packaging/actions/runs/26172953696/job/77005567053