### PR TITLE
update some URLs in deb/rpm metadata

### DIFF
--- a/pkg/agent/deb/control
+++ b/pkg/agent/deb/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Docker <support@docker.com>
 Homepage: https://www.docker.com
 Vcs-Browser: https://github.com/docker/docker-agent
-Vcs-Git: git://github.com/docker/docker-agent.git
+Vcs-Git: https://github.com/docker/docker-agent.git
 Standards-Version: 3.9.6
 Build-Depends: bash,
                gcc,

--- a/pkg/buildx/deb/control
+++ b/pkg/buildx/deb/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Docker <support@docker.com>
 Homepage: https://www.docker.com
 Vcs-Browser: https://github.com/docker/buildx
-Vcs-Git: git://github.com/docker/buildx.git
+Vcs-Git: https://github.com/docker/buildx.git
 Standards-Version: 3.9.6
 Build-Depends: bash,
                debhelper-compat (= 12)

--- a/pkg/compose/deb/control
+++ b/pkg/compose/deb/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Docker <support@docker.com>
 Homepage: https://www.docker.com
 Vcs-Browser: https://github.com/docker/compose
-Vcs-Git: git://github.com/docker/compose.git
+Vcs-Git: https://github.com/docker/compose.git
 Standards-Version: 3.9.6
 Build-Depends: bash,
                debhelper-compat (= 12),

--- a/pkg/credential-helpers/deb/control
+++ b/pkg/credential-helpers/deb/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Docker <support@docker.com>
 Homepage: https://www.docker.com
 Vcs-Browser: https://github.com/docker/docker-credential-helpers
-Vcs-Git: git://github.com/docker/docker-credential-helpers.git
+Vcs-Git: https://github.com/docker/docker-credential-helpers.git
 Standards-Version: 3.9.6
 Build-Depends: debhelper-compat (= 12),
                gcc,

--- a/pkg/docker-cli/deb/control
+++ b/pkg/docker-cli/deb/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Docker <support@docker.com>
 Homepage: https://www.docker.com
 Vcs-Browser: https://github.com/docker/cli
-Vcs-Git: git://github.com/docker/cli.git
+Vcs-Git: https://github.com/docker/cli.git
 Standards-Version: 3.9.6
 Build-Depends: bash,
                bash-completion,

--- a/pkg/docker-engine/deb/control
+++ b/pkg/docker-engine/deb/control
@@ -60,4 +60,4 @@ Breaks: rootlesskit
 Description: Rootless support for Docker.
   Use dockerd-rootless.sh to run the daemon.
   Use dockerd-rootless-setuptool.sh to setup systemd for dockerd-rootless.sh .
-Homepage: https://docs.docker.com/engine/security/rootless/
+Homepage: https://docs.docker.com/go/rootless/

--- a/pkg/docker-engine/deb/control
+++ b/pkg/docker-engine/deb/control
@@ -3,8 +3,8 @@ Section: admin
 Priority: optional
 Maintainer: Docker <support@docker.com>
 Homepage: https://www.docker.com
-Vcs-Browser: https://github.com/docker/docker
-Vcs-Git: https://github.com/docker/docker.git
+Vcs-Browser: https://github.com/moby/moby
+Vcs-Git: https://github.com/moby/moby.git
 Standards-Version: 3.9.6
 Build-Depends: ca-certificates,
                cmake,

--- a/pkg/docker-engine/deb/control
+++ b/pkg/docker-engine/deb/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Docker <support@docker.com>
 Homepage: https://www.docker.com
 Vcs-Browser: https://github.com/docker/docker
-Vcs-Git: git://github.com/docker/docker.git
+Vcs-Git: https://github.com/docker/docker.git
 Standards-Version: 3.9.6
 Build-Depends: ca-certificates,
                cmake,

--- a/pkg/docker-engine/rpm/docker-ce-rootless-extras.spec
+++ b/pkg/docker-engine/rpm/docker-ce-rootless-extras.spec
@@ -8,7 +8,7 @@ Source0: engine.tgz
 Summary: Rootless support for Docker
 Group: Tools/Docker
 License: Apache-2.0
-URL: https://docs.docker.com/engine/security/rootless/
+URL: https://docs.docker.com/go/rootless/
 Vendor: Docker
 Packager: Docker <support@docker.com>
 

--- a/pkg/model/deb/control
+++ b/pkg/model/deb/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Docker <support@docker.com>
 Homepage: https://www.docker.com
 Vcs-Browser: https://github.com/docker/model-runner
-Vcs-Git: git://github.com/docker/model-runner.git
+Vcs-Git: https://github.com/docker/model-runner.git
 Standards-Version: 3.9.6
 Build-Depends: bash,
                debhelper-compat (= 12),


### PR DESCRIPTION
### pkg/*: remove uses of git:// scheme for Vcs-Git

GitHub hasn't supported the insecure Git protocol for Years; let's
just use the https:// scheme, which should work.

### pkg/docker-engine: update repository url

### pkg/docker-engine: use "/go/" redirect for rootless
