### PR TITLE
README: remove "experimental" note

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,5 @@
 # Docker Packaging
 
-## :test_tube: Experimental
-
-This repository is considered **EXPERIMENTAL** and under active development
-until further notice. Please refer to [`docker-ce-packaging` repository](https://github.com/docker/docker-ce-packaging)
-to request changes to the packaging process.
-
 ## About
 
 This repository creates packages (deb, rpm, static) for various projects and


### PR DESCRIPTION
This repository is now our main packaging repository, and docker-ce-packaging is in process of being phased out.