### PR TITLE
 pkg/docker-engine, cli: update "conflicts"

### DIFF
--- a/pkg/docker-cli/deb/control
+++ b/pkg/docker-cli/deb/control
@@ -19,7 +19,10 @@ Depends: ${shlibs:Depends}
 Recommends: docker-buildx-plugin,
             docker-compose-plugin
 Suggests: docker-model-plugin
-Conflicts: docker.io
+# Debian Trixie ships the CLI as docker-cli; older Debian releases and
+# Ubuntu include it in docker.io.
+Conflicts: docker.io,
+           docker-cli
 Replaces: docker-ce (<< 5:0)
 Breaks: docker-ce (<< 5:0)
 Description: Docker CLI: the open-source application container engine

--- a/pkg/docker-cli/deb/control
+++ b/pkg/docker-cli/deb/control
@@ -19,8 +19,7 @@ Depends: ${shlibs:Depends}
 Recommends: docker-buildx-plugin,
             docker-compose-plugin
 Suggests: docker-model-plugin
-Conflicts: docker (<< 1.5~),
-           docker.io
+Conflicts: docker.io
 Replaces: docker-ce (<< 5:0)
 Breaks: docker-ce (<< 5:0)
 Description: Docker CLI: the open-source application container engine

--- a/pkg/docker-cli/deb/control
+++ b/pkg/docker-cli/deb/control
@@ -20,7 +20,6 @@ Recommends: docker-buildx-plugin,
             docker-compose-plugin
 Suggests: docker-model-plugin
 Conflicts: docker (<< 1.5~),
-           docker-engine,
            docker.io
 Replaces: docker-ce (<< 5:0)
 Breaks: docker-ce (<< 5:0)

--- a/pkg/docker-engine/deb/control
+++ b/pkg/docker-engine/deb/control
@@ -34,10 +34,8 @@ Recommends: apparmor,
             xz-utils
 Suggests: cgroupfs-mount | cgroup-lite
 Conflicts: docker (<< 1.5~),
-           docker-engine,
            docker.io
-Replaces: docker-engine,
-          docker-ce-cli (<< 5:28.0.0)
+Replaces: docker-ce-cli (<< 5:28.0.0)
 Description: Docker: the open-source application container engine
  Docker is a product for you to build, ship and run any application as a
  lightweight container

--- a/pkg/docker-engine/deb/control
+++ b/pkg/docker-engine/deb/control
@@ -33,8 +33,7 @@ Recommends: apparmor,
             procps,
             xz-utils
 Suggests: cgroupfs-mount | cgroup-lite
-Conflicts: docker (<< 1.5~),
-           docker.io
+Conflicts: docker.io
 Replaces: docker-ce-cli (<< 5:28.0.0)
 Description: Docker: the open-source application container engine
  Docker is a product for you to build, ship and run any application as a

--- a/pkg/docker-engine/rpm/docker-ce.spec
+++ b/pkg/docker-engine/rpm/docker-ce.spec
@@ -50,7 +50,6 @@ Conflicts: docker-ee
 
 Obsoletes: docker-ce-selinux
 Obsoletes: docker-engine-selinux
-Obsoletes: docker-engine
 
 %description
 Docker is a product for you to build, ship and run any application as a

--- a/pkg/docker-engine/rpm/docker-ce.spec
+++ b/pkg/docker-engine/rpm/docker-ce.spec
@@ -48,9 +48,6 @@ Conflicts: docker
 Conflicts: docker-io
 Conflicts: docker-ee
 
-Obsoletes: docker-ce-selinux
-Obsoletes: docker-engine-selinux
-
 %description
 Docker is a product for you to build, ship and run any application as a
 lightweight container.


### PR DESCRIPTION
- fixes https://github.com/docker/packaging/issues/435
- relates to https://github.com/docker/docker-ce-packaging/pull/1155
- relates to https://github.com/docker/docker-ce-packaging/pull/17

### pkg/docker-engine, cli: remove "conflicts: docker-engine"

The docker-engine package pre-dates docker-ce (< 17.03), and this
package was never published to download.docker.com, so is very
unlikely to be found anywhere.

### pkg/docker-engine, cli: remove "conflicts: docker"

The `docker` package is now a transitional package with a dependency
on `wmdocker`, and the `docker` package was removed entirely since
Debian 13 (trixy) and Ubuntu 22.10

- https://packages.debian.org/bullseye/docker
- https://packages.debian.org/bullseye/wmdocker

Neither have a binary named `docker`, or docs that conflict;

- https://packages.debian.org/bookworm/amd64/docker/filelist
- https://packages.debian.org/bookworm/amd64/wmdocker/filelist

So we don't have any conflicts if both would be installed.


### pkg/docker-cli: deb: conflict with docker-cli packages

Debian Trixie now ships the Docker CLI as a separate docker-cli package,
while Ubuntu and older Debian releases include it in docker.io.

Add a conflict with docker-cli to prevent file overlaps with the CLI
binaries provided by docker-ce-cli.


### pkg/docker-engine: rpm: remove Obsoletes for obsolete (selinux) packages

similar to:  https://github.com/docker/docker-ce-packaging/commit/4608bdfb234b60beae81487a8d5cb20cb2966fc7

Remove the obsoletes for `docker-ce-selinux`, `docker-engine-selinux`

These were obsoleted in 2017 through https://github.com/docker/docker-ce-packaging/commit/94943b47520aa81bbe30fbc4eb927c79047ef6d2

> Mark docker-*-selinux pkgs as obsolete
>
> These are replaced by `container-selinux` on fedora-25 and centos-7.
> Marking these packages as obsolete makes the installation process a bit
> smoother, otherwise the user will have to manually uninstall the older
> packages to install the new one.
>
> Also makes fedora24 use container-selinux which is now supports labeling
> the `dockerd` binary correctly.

Both CentOS 6/7 and Fedora 25 are EOL now, and these packages have not been
published for a long time. Time to remove them, also to reduce some noise
during builds;

    RPM build warnings:
        line 51: It's not recommended to have unversioned Obsoletes: Obsoletes: docker-ce-selinux
        line 52: It's not recommended to have unversioned Obsoletes: Obsoletes: docker-engine-selinux
        line 53: It's not recommended to have unversioned Obsoletes: Obsoletes: docker-engine

