### PR TITLE
Revert "gha/update-go: Immediately trigger workflows in PR"

### DIFF
--- a/.github/workflows/update-go.yml
+++ b/.github/workflows/update-go.yml
@@ -25,15 +25,6 @@ jobs:
       - pkgs
     steps:
       -
-        name: Generate app token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        id: generate-token
-        with:
-          app-id: ${{ vars.DOCKER_READ_WRITE_APP_ID }}
-          private-key: ${{ secrets.DOCKER_READ_WRITE_APP_PRIVATE_KEY }}
-          permission-contents: write
-          permission-pull-requests: write
-      -
         name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       -
@@ -129,7 +120,6 @@ jobs:
         name: Create PR
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
         with:
-          token: ${{ steps.generate-token.outputs.token }}
           base: main
           branch: bot/update-go
           signoff: true


### PR DESCRIPTION
Turns out our public repo doesn't have access to the read-write app secret.