### PR TITLE
deb: add missing pre-depends for init-system-helpers

### DIFF
--- a/pkg/docker-engine/deb/control
+++ b/pkg/docker-engine/deb/control
@@ -20,6 +20,7 @@ Build-Depends: ca-certificates,
 
 Package: docker-ce
 Architecture: linux-any
+Pre-Depends: init-system-helpers (>= 1.54~)
 Depends: containerd.io (>= 1.7.27),
          docker-ce-cli,
          iptables,


### PR DESCRIPTION
- porting https://github.com/docker/docker-ce-packaging/pull/1199


Before this patch, lintian would complain about missing pre-depends:

    lintian ./*.deb
    ...
    W: docker-ce: skip-systemd-native-flag-missing-pre-depends (does not satisfy init-system-helpers:any) [postinst:51]
    W: docker-ce: skip-systemd-native-flag-missing-pre-depends (does not satisfy init-system-helpers:any) [prerm:10]
