### PR TITLE
gha/c8d: Add Go version override

### DIFF
--- a/.github/workflows/release-containerd.yml
+++ b/.github/workflows/release-containerd.yml
@@ -19,6 +19,11 @@ on:
         required: false
         type: string
         default: ''
+      go_version:
+        description: '(optional) Go version to use for building packages. Defaults to the pinned containerd version.'
+        required: false
+        type: string
+        default: ''
       release:
         description: '(optional) Release type to create in https://github.com/docker/packaging/releases'
         required: false
@@ -61,6 +66,7 @@ jobs:
         PKG_DEB_REVISION=${{ inputs.revision }}
         PKG_RPM_RELEASE=${{ inputs.revision }}
         RUNC_REF=${{ inputs.runc_ref }}
+        GO_VERSION=${{ inputs.go_version }}
     secrets:
       rh_user: ${{ secrets.RH_USER }}
       rh_pass: ${{ secrets.RH_PASS }}


### PR DESCRIPTION
This allows to override Go to newer version when building different containerd version than we currently consider stable.

For example, I want to build 2.3 for the testing channel, but it currently fails because 2.3 is on Go 1.26 already:

```
go: go.mod requires go >= 1.26.3 (running go 1.25.10; GOTOOLCHAIN=local)
```