### PR TITLE
pkg/*: deb: remove redundant dh_overrides

### DIFF
--- a/pkg/agent/deb/rules
+++ b/pkg/agent/deb/rules
@@ -27,14 +27,8 @@ override_dh_dwz:
 override_dh_auto_install:
 	install -D -p -m 0755 /usr/libexec/docker/cli-plugins/docker-agent debian/docker-agent-plugin/usr/libexec/docker/cli-plugins/docker-agent
 
-override_dh_installinit:
-	dh_installinit
-
 override_dh_shlibdeps:
 	dh_shlibdeps --dpkg-shlibdeps-params=--ignore-missing-info
-
-override_dh_install:
-	dh_install
 
 override_dh_gencontrol:
 	dh_gencontrol --remaining-packages

--- a/pkg/buildx/deb/rules
+++ b/pkg/buildx/deb/rules
@@ -30,14 +30,8 @@ override_dh_dwz:
 override_dh_auto_install:
 	install -D -p -m 0755 /usr/libexec/docker/cli-plugins/docker-buildx debian/docker-buildx-plugin/usr/libexec/docker/cli-plugins/docker-buildx
 
-override_dh_installinit:
-	dh_installinit
-
 override_dh_shlibdeps:
 	dh_shlibdeps --dpkg-shlibdeps-params=--ignore-missing-info
-
-override_dh_install:
-	dh_install
 
 override_dh_gencontrol:
 	dh_gencontrol --remaining-packages

--- a/pkg/compose/deb/rules
+++ b/pkg/compose/deb/rules
@@ -25,14 +25,8 @@ override_dh_dwz:
 override_dh_auto_install:
 	install -D -p -m 0755 /usr/libexec/docker/cli-plugins/docker-compose debian/docker-compose-plugin/usr/libexec/docker/cli-plugins/docker-compose
 
-override_dh_installinit:
-	dh_installinit
-
 override_dh_shlibdeps:
 	dh_shlibdeps --dpkg-shlibdeps-params=--ignore-missing-info
-
-override_dh_install:
-	dh_install
 
 override_dh_gencontrol:
 	dh_gencontrol --remaining-packages

--- a/pkg/docker-cli/deb/rules
+++ b/pkg/docker-cli/deb/rules
@@ -59,14 +59,8 @@ override_dh_auto_install:
 	install -D -p -m 0644 cli/build/completion/fish/docker.fish debian/docker-ce-cli/usr/share/fish/vendor_completions.d/docker.fish
 	install -D -p -m 0644 cli/build/completion/zsh/_docker debian/docker-ce-cli/usr/share/zsh/vendor-completions/_docker
 
-override_dh_installinit:
-	dh_installinit
-
 override_dh_shlibdeps:
 	dh_shlibdeps --dpkg-shlibdeps-params=--ignore-missing-info
-
-override_dh_install:
-	dh_install
 
 override_dh_gencontrol:
 	dh_gencontrol --remaining-packages

--- a/pkg/model/deb/rules
+++ b/pkg/model/deb/rules
@@ -26,14 +26,8 @@ override_dh_dwz:
 override_dh_auto_install:
 	install -D -p -m 0755 /usr/libexec/docker/cli-plugins/docker-model debian/docker-model-plugin/usr/libexec/docker/cli-plugins/docker-model
 
-override_dh_installinit:
-	dh_installinit
-
 override_dh_shlibdeps:
 	dh_shlibdeps --dpkg-shlibdeps-params=--ignore-missing-info
-
-override_dh_install:
-	dh_install
 
 override_dh_gencontrol:
 	dh_gencontrol --remaining-packages


### PR DESCRIPTION
These overrides were aliasing the default without modifications, so are not needed.