### PR TITLE
pkg/*: deb: remove --dpkg-shlibdeps-params=--ignore-missing-info override

### DIFF
--- a/pkg/agent/deb/rules
+++ b/pkg/agent/deb/rules
@@ -27,9 +27,6 @@ override_dh_dwz:
 override_dh_auto_install:
 	install -D -p -m 0755 /usr/libexec/docker/cli-plugins/docker-agent debian/docker-agent-plugin/usr/libexec/docker/cli-plugins/docker-agent
 
-override_dh_shlibdeps:
-	dh_shlibdeps --dpkg-shlibdeps-params=--ignore-missing-info
-
 override_dh_gencontrol:
 	dh_gencontrol --remaining-packages
 

--- a/pkg/buildx/deb/rules
+++ b/pkg/buildx/deb/rules
@@ -30,9 +30,6 @@ override_dh_dwz:
 override_dh_auto_install:
 	install -D -p -m 0755 /usr/libexec/docker/cli-plugins/docker-buildx debian/docker-buildx-plugin/usr/libexec/docker/cli-plugins/docker-buildx
 
-override_dh_shlibdeps:
-	dh_shlibdeps --dpkg-shlibdeps-params=--ignore-missing-info
-
 override_dh_gencontrol:
 	dh_gencontrol --remaining-packages
 

--- a/pkg/compose/deb/rules
+++ b/pkg/compose/deb/rules
@@ -25,9 +25,6 @@ override_dh_dwz:
 override_dh_auto_install:
 	install -D -p -m 0755 /usr/libexec/docker/cli-plugins/docker-compose debian/docker-compose-plugin/usr/libexec/docker/cli-plugins/docker-compose
 
-override_dh_shlibdeps:
-	dh_shlibdeps --dpkg-shlibdeps-params=--ignore-missing-info
-
 override_dh_gencontrol:
 	dh_gencontrol --remaining-packages
 

--- a/pkg/docker-cli/deb/rules
+++ b/pkg/docker-cli/deb/rules
@@ -59,9 +59,6 @@ override_dh_auto_install:
 	install -D -p -m 0644 cli/build/completion/fish/docker.fish debian/docker-ce-cli/usr/share/fish/vendor_completions.d/docker.fish
 	install -D -p -m 0644 cli/build/completion/zsh/_docker debian/docker-ce-cli/usr/share/zsh/vendor-completions/_docker
 
-override_dh_shlibdeps:
-	dh_shlibdeps --dpkg-shlibdeps-params=--ignore-missing-info
-
 override_dh_gencontrol:
 	dh_gencontrol --remaining-packages
 

--- a/pkg/docker-engine/deb/rules
+++ b/pkg/docker-engine/deb/rules
@@ -45,9 +45,6 @@ override_dh_installsystemd:
 	# use "docker" as our service name, not "docker-ce"
 	dh_installsystemd --name=docker
 
-override_dh_shlibdeps:
-	dh_shlibdeps --dpkg-shlibdeps-params=--ignore-missing-info
-
 override_dh_install:
 	dh_install
 	# TODO Can we do this from within our container?

--- a/pkg/model/deb/rules
+++ b/pkg/model/deb/rules
@@ -26,9 +26,6 @@ override_dh_dwz:
 override_dh_auto_install:
 	install -D -p -m 0755 /usr/libexec/docker/cli-plugins/docker-model debian/docker-model-plugin/usr/libexec/docker/cli-plugins/docker-model
 
-override_dh_shlibdeps:
-	dh_shlibdeps --dpkg-shlibdeps-params=--ignore-missing-info
-
 override_dh_gencontrol:
 	dh_gencontrol --remaining-packages
 


### PR DESCRIPTION
- [x] depends on / stacked on https://github.com/docker/packaging/pull/450
- relates to https://github.com/moby/moby/pull/21387

### pkg/*: deb: remove --dpkg-shlibdeps-params=--ignore-missing-info override

This override was originally added in [moby@bb66d71] in 2016, which updated
the build scripts for building the new `containerd`, `containerd-shim`, `ctr`,
and `runc` binaries.

Unfortunately, the pull request did not call-out the reason for adding this
specific override, but there was a discussion about some distros not having
the required GCC version to compile seccomp;

> This is currently failing on oracle linux-6 because it can't compile runc
> (...) It looks like it is related to this bug: seccomp/libseccomp-golang#2
> which states that the gcc version is too old. Currently, the gcc version
> that comes with oracle linux 6 is gcc (GCC) 4.4.7 20120313 (Red Hat 4.4.7-16)
>
> ...
>
> It looks like ubuntu precise has the same gcc issue, it isn't new enough.
> Looks like the newest version that is apt is 4.6.3, and I need at least
> 4.6.4.

The [dpkg-shlibdeps(1)] manpage explicitly calls this option out as discouraged:

    --ignore-missing-info
    
      Do not fail if dependency information can't be found for a shared library
      (since dpkg 1.14.8). Usage of this option is discouraged, all libraries
      should provide dependency information (either with shlibs files, or with
      symbols files) even if they are not yet used by other packages.

Since then, this option was copied to all the deb packages we build.

Let's remove this option, as it's discouraged, may be hiding real problems
(missing dependencies that would otherwise fail the build), and very likely
was never needed for most CLI binaries, and likely no longer needed for the
dockerd and containerd binaries (the containerd packaging scripts do not even
have this option set).

[moby@bb66d71]: https://github.com/moby/moby/commit/bb66d7144f7d0a617f5985486ae36bbbaa5461ba
[dpkg-shlibdeps(1)]: https://manpages.debian.org/trixie/dpkg-dev/dpkg-shlibdeps.1.en.html#ignore