### PR TITLE
pkg/*: deb: remove redundant override_dh_gencontrol

### DIFF
--- a/pkg/agent/deb/rules
+++ b/pkg/agent/deb/rules
@@ -27,8 +27,5 @@ override_dh_dwz:
 override_dh_auto_install:
 	install -D -p -m 0755 /usr/libexec/docker/cli-plugins/docker-agent debian/docker-agent-plugin/usr/libexec/docker/cli-plugins/docker-agent
 
-override_dh_gencontrol:
-	dh_gencontrol --remaining-packages
-
 %:
 	dh $@

--- a/pkg/buildx/deb/rules
+++ b/pkg/buildx/deb/rules
@@ -30,8 +30,5 @@ override_dh_dwz:
 override_dh_auto_install:
 	install -D -p -m 0755 /usr/libexec/docker/cli-plugins/docker-buildx debian/docker-buildx-plugin/usr/libexec/docker/cli-plugins/docker-buildx
 
-override_dh_gencontrol:
-	dh_gencontrol --remaining-packages
-
 %:
 	dh $@

--- a/pkg/compose/deb/rules
+++ b/pkg/compose/deb/rules
@@ -25,8 +25,5 @@ override_dh_dwz:
 override_dh_auto_install:
 	install -D -p -m 0755 /usr/libexec/docker/cli-plugins/docker-compose debian/docker-compose-plugin/usr/libexec/docker/cli-plugins/docker-compose
 
-override_dh_gencontrol:
-	dh_gencontrol --remaining-packages
-
 %:
 	dh $@

--- a/pkg/docker-cli/deb/rules
+++ b/pkg/docker-cli/deb/rules
@@ -59,8 +59,5 @@ override_dh_auto_install:
 	install -D -p -m 0644 cli/build/completion/fish/docker.fish debian/docker-ce-cli/usr/share/fish/vendor_completions.d/docker.fish
 	install -D -p -m 0644 cli/build/completion/zsh/_docker debian/docker-ce-cli/usr/share/zsh/vendor-completions/_docker
 
-override_dh_gencontrol:
-	dh_gencontrol --remaining-packages
-
 %:
 	dh $@ --with=bash-completion

--- a/pkg/docker-engine/deb/rules
+++ b/pkg/docker-engine/deb/rules
@@ -50,8 +50,5 @@ override_dh_install:
 	# TODO Can we do this from within our container?
 	dh_apparmor --profile-name=docker-ce -pdocker-ce
 
-override_dh_gencontrol:
-	dh_gencontrol --remaining-packages
-
 %:
 	dh $@

--- a/pkg/model/deb/rules
+++ b/pkg/model/deb/rules
@@ -26,8 +26,5 @@ override_dh_dwz:
 override_dh_auto_install:
 	install -D -p -m 0755 /usr/libexec/docker/cli-plugins/docker-model debian/docker-model-plugin/usr/libexec/docker/cli-plugins/docker-model
 
-override_dh_gencontrol:
-	dh_gencontrol --remaining-packages
-
 %:
 	dh $@


### PR DESCRIPTION
- relates to https://github.com/docker/docker-ce-packaging/pull/537
- [x] stacked on https://github.com/docker/packaging/pull/450
- [x] stacked on https://github.com/docker/packaging/pull/451


### pkg/*: deb: remove redundant override_dh_gencontrol

The `--remaining-packages` option was added in [docker-ce-packaging@3e78175],
which manually called `dh_gencontrol` for a single package, after which it
had to call `dh_gencontrol --remaining-packages` to process the remaining
packages as usual.

This override was removed, so `dh_gencontrol --remaining-packages` is no
longer needed, and we can remove the override.

This option was copied to all other packages, which never needed it, so
removing it there as well.

[docker-ce-packaging@3e78175]: https://github.com/docker/docker-ce-packaging/commit/3e781759f2d0ddcefdd7299e04a299c21c677790