### PR TITLE
ci: use Docker Hub workflow inputs for registry login

### DIFF
--- a/.github/workflows/.build.yml
+++ b/.github/workflows/.build.yml
@@ -16,14 +16,15 @@ on:
       distros:
         required: false
         type: string
+      dockerhub_username:
+        required: false
+        type: string
     secrets:
       rh_user:
         required: false
       rh_pass:
         required: false
-      dockerpublicbot_username:
-        required: false
-      dockerpublicbot_write_pat:
+      dockerhub_token:
         required: false
       ghtoken:
         required: false
@@ -257,8 +258,8 @@ jobs:
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         if: ${{ inputs.release || github.event_name == 'schedule' }}
         with:
-          username: ${{ secrets.dockerpublicbot_username }}
-          password: ${{ secrets.dockerpublicbot_write_pat }}
+          username: ${{ inputs.dockerhub_username }}
+          password: ${{ secrets.dockerhub_token }}
       -
         name: Build release
         id: build

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -32,8 +32,8 @@ jobs:
       release: pushonly
       envs: |
         NIGHTLY_BUILD=1
+      dockerhub_username: ${{ vars.DOCKERPUBLICBOT_USERNAME }}
     secrets:
       rh_user: ${{ secrets.RH_USER }}
       rh_pass: ${{ secrets.RH_PASS }}
-      dockerpublicbot_username: ${{ secrets.DOCKERPUBLICBOT_USERNAME }}
-      dockerpublicbot_write_pat: ${{ secrets.DOCKERPUBLICBOT_WRITE_PAT }}
+      dockerhub_token: ${{ secrets.DOCKERPUBLICBOT_WRITE_PAT }}

--- a/.github/workflows/release-agent.yml
+++ b/.github/workflows/release-agent.yml
@@ -55,8 +55,8 @@ jobs:
         PKG_REF=${{ inputs.ref }}
         PKG_DEB_REVISION=${{ inputs.revision }}
         PKG_RPM_RELEASE=${{ inputs.revision }}
+      dockerhub_username: ${{ vars.DOCKERPUBLICBOT_USERNAME }}
     secrets:
       rh_user: ${{ secrets.RH_USER }}
       rh_pass: ${{ secrets.RH_PASS }}
-      dockerpublicbot_username: ${{ secrets.DOCKERPUBLICBOT_USERNAME }}
-      dockerpublicbot_write_pat: ${{ secrets.DOCKERPUBLICBOT_WRITE_PAT }}
+      dockerhub_token: ${{ secrets.DOCKERPUBLICBOT_WRITE_PAT }}

--- a/.github/workflows/release-buildx.yml
+++ b/.github/workflows/release-buildx.yml
@@ -55,8 +55,8 @@ jobs:
         PKG_REF=${{ inputs.ref }}
         PKG_DEB_REVISION=${{ inputs.revision }}
         PKG_RPM_RELEASE=${{ inputs.revision }}
+      dockerhub_username: ${{ vars.DOCKERPUBLICBOT_USERNAME }}
     secrets:
       rh_user: ${{ secrets.RH_USER }}
       rh_pass: ${{ secrets.RH_PASS }}
-      dockerpublicbot_username: ${{ secrets.DOCKERPUBLICBOT_USERNAME }}
-      dockerpublicbot_write_pat: ${{ secrets.DOCKERPUBLICBOT_WRITE_PAT }}
+      dockerhub_token: ${{ secrets.DOCKERPUBLICBOT_WRITE_PAT }}

--- a/.github/workflows/release-compose.yml
+++ b/.github/workflows/release-compose.yml
@@ -55,8 +55,8 @@ jobs:
         PKG_REF=${{ inputs.ref }}
         PKG_DEB_REVISION=${{ inputs.revision }}
         PKG_RPM_RELEASE=${{ inputs.revision }}
+      dockerhub_username: ${{ vars.DOCKERPUBLICBOT_USERNAME }}
     secrets:
       rh_user: ${{ secrets.RH_USER }}
       rh_pass: ${{ secrets.RH_PASS }}
-      dockerpublicbot_username: ${{ secrets.DOCKERPUBLICBOT_USERNAME }}
-      dockerpublicbot_write_pat: ${{ secrets.DOCKERPUBLICBOT_WRITE_PAT }}
+      dockerhub_token: ${{ secrets.DOCKERPUBLICBOT_WRITE_PAT }}

--- a/.github/workflows/release-containerd.yml
+++ b/.github/workflows/release-containerd.yml
@@ -67,8 +67,8 @@ jobs:
         PKG_RPM_RELEASE=${{ inputs.revision }}
         RUNC_REF=${{ inputs.runc_ref }}
         GO_VERSION=${{ inputs.go_version }}
+      dockerhub_username: ${{ vars.DOCKERPUBLICBOT_USERNAME }}
     secrets:
       rh_user: ${{ secrets.RH_USER }}
       rh_pass: ${{ secrets.RH_PASS }}
-      dockerpublicbot_username: ${{ secrets.DOCKERPUBLICBOT_USERNAME }}
-      dockerpublicbot_write_pat: ${{ secrets.DOCKERPUBLICBOT_WRITE_PAT }}
+      dockerhub_token: ${{ secrets.DOCKERPUBLICBOT_WRITE_PAT }}

--- a/.github/workflows/release-credential-helpers.yml
+++ b/.github/workflows/release-credential-helpers.yml
@@ -55,8 +55,8 @@ jobs:
         PKG_REF=${{ inputs.ref }}
         PKG_DEB_REVISION=${{ inputs.revision }}
         PKG_RPM_RELEASE=${{ inputs.revision }}
+      dockerhub_username: ${{ vars.DOCKERPUBLICBOT_USERNAME }}
     secrets:
       rh_user: ${{ secrets.RH_USER }}
       rh_pass: ${{ secrets.RH_PASS }}
-      dockerpublicbot_username: ${{ secrets.DOCKERPUBLICBOT_USERNAME }}
-      dockerpublicbot_write_pat: ${{ secrets.DOCKERPUBLICBOT_WRITE_PAT }}
+      dockerhub_token: ${{ secrets.DOCKERPUBLICBOT_WRITE_PAT }}

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -67,11 +67,11 @@ jobs:
         PKG_REF=${{ inputs.engine-ref }}
         PKG_DEB_REVISION=${{ inputs.revision }}
         PKG_RPM_RELEASE=${{ inputs.revision }}
+      dockerhub_username: ${{ vars.DOCKERPUBLICBOT_USERNAME }}
     secrets:
       rh_user: ${{ secrets.RH_USER }}
       rh_pass: ${{ secrets.RH_PASS }}
-      dockerpublicbot_username: ${{ secrets.DOCKERPUBLICBOT_USERNAME }}
-      dockerpublicbot_write_pat: ${{ secrets.DOCKERPUBLICBOT_WRITE_PAT }}
+      dockerhub_token: ${{ secrets.DOCKERPUBLICBOT_WRITE_PAT }}
 
   cli:
     uses: ./.github/workflows/.build.yml
@@ -86,8 +86,8 @@ jobs:
         PKG_REF=${{ inputs.cli-ref }}
         PKG_DEB_REVISION=${{ inputs.revision }}
         PKG_RPM_RELEASE=${{ inputs.revision }}
+      dockerhub_username: ${{ vars.DOCKERPUBLICBOT_USERNAME }}
     secrets:
       rh_user: ${{ secrets.RH_USER }}
       rh_pass: ${{ secrets.RH_PASS }}
-      dockerpublicbot_username: ${{ secrets.DOCKERPUBLICBOT_USERNAME }}
-      dockerpublicbot_write_pat: ${{ secrets.DOCKERPUBLICBOT_WRITE_PAT }}
+      dockerhub_token: ${{ secrets.DOCKERPUBLICBOT_WRITE_PAT }}

--- a/.github/workflows/release-model.yml
+++ b/.github/workflows/release-model.yml
@@ -55,8 +55,8 @@ jobs:
         PKG_REF=${{ inputs.ref }}
         PKG_DEB_REVISION=${{ inputs.revision }}
         PKG_RPM_RELEASE=${{ inputs.revision }}
+      dockerhub_username: ${{ vars.DOCKERPUBLICBOT_USERNAME }}
     secrets:
       rh_user: ${{ secrets.RH_USER }}
       rh_pass: ${{ secrets.RH_PASS }}
-      dockerpublicbot_username: ${{ secrets.DOCKERPUBLICBOT_USERNAME }}
-      dockerpublicbot_write_pat: ${{ secrets.DOCKERPUBLICBOT_WRITE_PAT }}
+      dockerhub_token: ${{ secrets.DOCKERPUBLICBOT_WRITE_PAT }}


### PR DESCRIPTION
replace `${{ secrets.DOCKERPUBLICBOT_USERNAME }}` with org-wide var `${{ vars.DOCKERPUBLICBOT_USERNAME }}`. This secret was manually created when there was not yet a org-wide var available. Will remove it when merged.