### PR TITLE
pkg/docker-engine: require containerd.io >= v2.1.5

### DIFF
--- a/pkg/docker-engine/deb/control
+++ b/pkg/docker-engine/deb/control
@@ -21,7 +21,7 @@ Build-Depends: ca-certificates,
 Package: docker-ce
 Architecture: linux-any
 Pre-Depends: init-system-helpers (>= 1.54~)
-Depends: containerd.io (>= 1.7.27),
+Depends: containerd.io (>= 2.1.5),
          docker-ce-cli,
          iptables,
          nftables,

--- a/pkg/docker-engine/rpm/docker-ce.spec
+++ b/pkg/docker-engine/rpm/docker-ce.spec
@@ -23,7 +23,7 @@ Requires: nftables
 # Libcgroup is no longer available in RHEL/CentOS >= 9 distros.
 Requires: libcgroup
 %endif
-Requires: containerd.io >= 1.7.27
+Requires: containerd.io >= 2.1.5
 Requires: tar
 Requires: xz
 


### PR DESCRIPTION
- [x] stacked on https://github.com/docker/packaging/pull/446
- similar to https://github.com/docker/docker-ce-packaging/pull/1334

### pkg/docker-engine: require containerd.io >= v2.1.5

Drop support for containerd.io v1.x. container.io v2.1.5 is the
oldest v2 version we shipped as packages.
