### PR TITLE
static: Use bin/share/doc layout in archives

### DIFF
--- a/pkg/agent/scripts/pkg-static-build.sh
+++ b/pkg/agent/scripts/pkg-static-build.sh
@@ -70,21 +70,21 @@ mkdir -p "${pkgoutput}"
 cd "$BUILDDIR"
 for pkgname in *; do
   workdir=$(mktemp -d -t docker-packaging.XXXXXXXXXX)
-  mkdir -p "$workdir/${pkgname}"
+  mkdir -p "$workdir/bin" "$workdir/share/doc/${pkgname}"
   (
     set -x
-    cp "${pkgname}"/* ${SRCDIR}/LICENSE ${SRCDIR}/README.md "$workdir/${pkgname}/"
+    cp "${pkgname}"/* "$workdir/bin/"
+    cp "${SRCDIR}/LICENSE" "${SRCDIR}/README.md" "$workdir/share/doc/${pkgname}/"
   )
   if [ "$(xx-info os)" = "windows" ]; then
     (
       set -x
-      cd "$workdir"
-      zip -r "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.zip" "${pkgname}"
+      cd "$workdir" && zip -r "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.zip" .
     )
   else
     (
       set -x
-      tar -czf "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.tgz" -C "$workdir" "${pkgname}"
+      tar -czf "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.tgz" -C "$workdir" .
     )
   fi
 done

--- a/pkg/agent/verify.Dockerfile
+++ b/pkg/agent/verify.Dockerfile
@@ -108,7 +108,7 @@ RUN --mount=from=bin,target=/build <<EOT
   for package in $(find $dir -type f -name '*.tgz'); do
     (
       set -x
-      tar zxvf $package -C /usr/bin --strip-components=1
+      tar zxvf $package -C /usr/local
     )
   done
   set -x

--- a/pkg/buildx/scripts/pkg-static-build.sh
+++ b/pkg/buildx/scripts/pkg-static-build.sh
@@ -67,21 +67,21 @@ mkdir -p "${pkgoutput}"
 cd "$BUILDDIR"
 for pkgname in *; do
   workdir=$(mktemp -d -t docker-packaging.XXXXXXXXXX)
-  mkdir -p "$workdir/${pkgname}"
+  mkdir -p "$workdir/bin" "$workdir/share/doc/${pkgname}"
   (
     set -x
-    cp "${pkgname}"/* ${SRCDIR}/LICENSE ${SRCDIR}/README.md "$workdir/${pkgname}/"
+    cp "${pkgname}"/* "$workdir/bin/"
+    cp "${SRCDIR}/LICENSE" "${SRCDIR}/README.md" "$workdir/share/doc/${pkgname}/"
   )
   if [ "$(xx-info os)" = "windows" ]; then
     (
       set -x
-      cd "$workdir"
-      zip -r "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.zip" "${pkgname}"
+      cd "$workdir" && zip -r "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.zip" .
     )
   else
     (
       set -x
-      tar -czf "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.tgz" -C "$workdir" "${pkgname}"
+      tar -czf "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.tgz" -C "$workdir" .
     )
   fi
 done

--- a/pkg/buildx/verify.Dockerfile
+++ b/pkg/buildx/verify.Dockerfile
@@ -108,7 +108,7 @@ RUN --mount=from=bin,target=/build <<EOT
   for package in $(find $dir -type f -name '*.tgz'); do
     (
       set -x
-      tar zxvf $package -C /usr/bin --strip-components=1
+      tar zxvf $package -C /usr/local
     )
   done
   set -x

--- a/pkg/compose/scripts/pkg-static-build.sh
+++ b/pkg/compose/scripts/pkg-static-build.sh
@@ -72,21 +72,21 @@ mkdir -p "${pkgoutput}"
 cd "$BUILDDIR"
 for pkgname in *; do
   workdir=$(mktemp -d -t docker-packaging.XXXXXXXXXX)
-  mkdir -p "$workdir/${pkgname}"
+  mkdir -p "$workdir/bin" "$workdir/share/doc/${pkgname}"
   (
     set -x
-    cp "${pkgname}"/* ${SRCDIR}/LICENSE ${SRCDIR}/README.md "$workdir/${pkgname}/"
+    cp "${pkgname}"/* "$workdir/bin/"
+    cp "${SRCDIR}/LICENSE" "${SRCDIR}/README.md" "$workdir/share/doc/${pkgname}/"
   )
   if [ "$(xx-info os)" = "windows" ]; then
     (
       set -x
-      cd "$workdir"
-      zip -r "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.zip" "${pkgname}"
+      cd "$workdir" && zip -r "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.zip" .
     )
   else
     (
       set -x
-      tar -czf "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.tgz" -C "$workdir" "${pkgname}"
+      tar -czf "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.tgz" -C "$workdir" .
     )
   fi
 done

--- a/pkg/compose/verify.Dockerfile
+++ b/pkg/compose/verify.Dockerfile
@@ -108,7 +108,7 @@ RUN --mount=from=bin,target=/build <<EOT
   for package in $(find $dir -type f -name '*.tgz'); do
     (
       set -x
-      tar zxvf $package -C /usr/bin --strip-components=1
+      tar zxvf $package -C /usr/local
     )
   done
   set -x

--- a/pkg/containerd/scripts/pkg-static-build.sh
+++ b/pkg/containerd/scripts/pkg-static-build.sh
@@ -119,28 +119,28 @@ mkdir -p "${pkgoutput}"
 cd "$BUILDDIR"
 for pkgname in *; do
   workdir=$(mktemp -d -t docker-packaging.XXXXXXXXXX)
-  mkdir -p "$workdir/${pkgname}"
+  mkdir -p "$workdir/bin" "$workdir/share/doc/${pkgname}"
   (
     set -x
-    cp "${pkgname}"/* ${SRCDIR}/LICENSE ${SRCDIR}/README.md "$workdir/${pkgname}/"
+    cp "${pkgname}"/* "$workdir/bin/"
+    cp "${SRCDIR}/LICENSE" "${SRCDIR}/README.md" "$workdir/share/doc/${pkgname}/"
     if [ "$(xx-info os)" = "windows" ]; then
-      cp ${RUNHCS_SRCDIR}/LICENSE "$workdir/${pkgname}/runhcs.LICENSE"
-      cp ${RUNHCS_SRCDIR}/README.md "$workdir/${pkgname}/runhcs.README.md"
+      cp "${RUNHCS_SRCDIR}/LICENSE" "$workdir/share/doc/${pkgname}/runhcs.LICENSE"
+      cp "${RUNHCS_SRCDIR}/README.md" "$workdir/share/doc/${pkgname}/runhcs.README.md"
     else
-      cp ${RUNC_SRCDIR}/LICENSE "$workdir/${pkgname}/runc.LICENSE"
-      cp ${RUNC_SRCDIR}/README.md "$workdir/${pkgname}/runc.README.md"
+      cp "${RUNC_SRCDIR}/LICENSE" "$workdir/share/doc/${pkgname}/runc.LICENSE"
+      cp "${RUNC_SRCDIR}/README.md" "$workdir/share/doc/${pkgname}/runc.README.md"
     fi
   )
   if [ "$(xx-info os)" = "windows" ]; then
     (
       set -x
-      cd "$workdir"
-      zip -r "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.zip" "${pkgname}"
+      cd "$workdir" && zip -r "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.zip" .
     )
   else
     (
       set -x
-      tar -czf "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.tgz" -C "$workdir" "${pkgname}"
+      tar -czf "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.tgz" -C "$workdir" .
     )
   fi
 done

--- a/pkg/containerd/verify.Dockerfile
+++ b/pkg/containerd/verify.Dockerfile
@@ -112,7 +112,7 @@ RUN --mount=from=bin,target=/build <<EOT
   for package in $(find $dir -type f -name '*.tgz'); do
     (
       set -x
-      tar zxvf $package -C /usr/bin --strip-components=1
+      tar zxvf $package -C /usr/local
     )
   done
   set -x

--- a/pkg/credential-helpers/scripts/pkg-static-build.sh
+++ b/pkg/credential-helpers/scripts/pkg-static-build.sh
@@ -94,21 +94,21 @@ mkdir -p "${pkgoutput}"
 cd "$BUILDDIR"
 for pkgname in *; do
   workdir=$(mktemp -d -t docker-packaging.XXXXXXXXXX)
-  mkdir -p "$workdir/${pkgname}"
+  mkdir -p "$workdir/bin" "$workdir/share/doc/${pkgname}"
   (
     set -x
-    cp "${pkgname}"/* ${SRCDIR}/LICENSE ${SRCDIR}/README.md "$workdir/${pkgname}/"
+    cp "${pkgname}"/* "$workdir/bin/"
+    cp "${SRCDIR}/LICENSE" "${SRCDIR}/README.md" "$workdir/share/doc/${pkgname}/"
   )
   if [ "$(xx-info os)" = "windows" ]; then
     (
       set -x
-      cd "$workdir"
-      zip -r "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.zip" "${pkgname}"
+      cd "$workdir" && zip -r "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.zip" .
     )
   else
     (
       set -x
-      tar -czf "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.tgz" -C "$workdir" "${pkgname}"
+      tar -czf "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.tgz" -C "$workdir" .
     )
   fi
 done

--- a/pkg/credential-helpers/verify.Dockerfile
+++ b/pkg/credential-helpers/verify.Dockerfile
@@ -121,7 +121,7 @@ RUN --mount=from=bin,target=/build <<EOT
   for package in $(find $dir -type f -name '*.tgz'); do
     (
       set -x
-      tar zxvf $package -C /usr/bin --strip-components=1
+      tar zxvf $package -C /usr/local
     )
   done
   set -x

--- a/pkg/docker-cli/scripts/pkg-static-build.sh
+++ b/pkg/docker-cli/scripts/pkg-static-build.sh
@@ -74,21 +74,21 @@ mkdir -p "${pkgoutput}"
 cd "$BUILDDIR"
 for pkgname in *; do
   workdir=$(mktemp -d -t docker-packaging.XXXXXXXXXX)
-  mkdir -p "$workdir/${pkgname}"
+  mkdir -p "$workdir/bin" "$workdir/share/doc/${pkgname}"
   (
     set -x
-    cp "${pkgname}"/* ${SRCDIR}/LICENSE ${SRCDIR}/README.md "$workdir/${pkgname}/"
+    cp "${pkgname}"/* "$workdir/bin/"
+    cp "${SRCDIR}/LICENSE" "${SRCDIR}/README.md" "$workdir/share/doc/${pkgname}/"
   )
   if [ "$(xx-info os)" = "windows" ]; then
     (
       set -x
-      cd "$workdir"
-      zip -r "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.zip" "${pkgname}"
+      cd "$workdir" && zip -r "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.zip" .
     )
   else
     (
       set -x
-      tar -czf "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.tgz" -C "$workdir" "${pkgname}"
+      tar -czf "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.tgz" -C "$workdir" .
     )
   fi
 done

--- a/pkg/docker-cli/verify.Dockerfile
+++ b/pkg/docker-cli/verify.Dockerfile
@@ -108,7 +108,7 @@ RUN --mount=from=bin,target=/build <<EOT
   for package in $(find $dir -type f -name '*.tgz'); do
     (
       set -x
-      tar zxvf $package -C /usr/bin --strip-components=1
+      tar zxvf $package -C /usr/local
     )
   done
   set -x

--- a/pkg/docker-engine/scripts/pkg-static-build.sh
+++ b/pkg/docker-engine/scripts/pkg-static-build.sh
@@ -92,21 +92,21 @@ mkdir -p "${pkgoutput}"
 cd "$BUILDDIR"
 for pkgname in *; do
   workdir=$(mktemp -d -t docker-packaging.XXXXXXXXXX)
-  mkdir -p "$workdir/${pkgname}"
+  mkdir -p "$workdir/bin" "$workdir/share/doc/${pkgname}"
   (
     set -x
-    cp "${pkgname}"/* ${SRCDIR}/LICENSE ${SRCDIR}/README.md "$workdir/${pkgname}/"
+    cp "${pkgname}"/* "$workdir/bin/"
+    cp "${SRCDIR}/LICENSE" "${SRCDIR}/README.md" "$workdir/share/doc/${pkgname}/"
   )
   if [ "$(xx-info os)" = "windows" ]; then
     (
       set -x
-      cd "$workdir"
-      zip -r "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.zip" "${pkgname}"
+      cd "$workdir" && zip -r "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.zip" .
     )
   else
     (
       set -x
-      tar -czf "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.tgz" -C "$workdir" "${pkgname}"
+      tar -czf "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.tgz" -C "$workdir" .
     )
   fi
 done

--- a/pkg/docker-engine/verify.Dockerfile
+++ b/pkg/docker-engine/verify.Dockerfile
@@ -121,7 +121,7 @@ RUN --mount=from=bin,target=/build <<EOT
   for package in $(find $dir -type f -name '*.tgz'); do
     (
       set -x
-      tar zxvf $package -C /usr/bin --strip-components=1
+      tar zxvf $package -C /usr/local
     )
   done
   set -x

--- a/pkg/model/scripts/pkg-static-build.sh
+++ b/pkg/model/scripts/pkg-static-build.sh
@@ -68,21 +68,21 @@ mkdir -p "${pkgoutput}"
 cd "$BUILDDIR"
 for pkgname in *; do
   workdir=$(mktemp -d -t docker-packaging.XXXXXXXXXX)
-  mkdir -p "$workdir/${pkgname}"
+  mkdir -p "$workdir/bin" "$workdir/share/doc/${pkgname}"
   (
     set -x
-    cp "${pkgname}"/* ${SRCDIR}/LICENSE "$workdir/${pkgname}/"
+    cp "${pkgname}"/* "$workdir/bin/"
+    cp "${SRCDIR}/LICENSE" "$workdir/share/doc/${pkgname}/"
   )
   if [ "$(xx-info os)" = "windows" ]; then
     (
       set -x
-      cd "$workdir"
-      zip -r "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.zip" "${pkgname}"
+      cd "$workdir" && zip -r "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.zip" .
     )
   else
     (
       set -x
-      tar -czf "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.tgz" -C "$workdir" "${pkgname}"
+      tar -czf "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.tgz" -C "$workdir" .
     )
   fi
 done

--- a/pkg/model/verify.Dockerfile
+++ b/pkg/model/verify.Dockerfile
@@ -108,7 +108,7 @@ RUN --mount=from=bin,target=/build <<EOT
   for package in $(find $dir -type f -name '*.tgz'); do
     (
       set -x
-      tar zxvf $package -C /usr/bin --strip-components=1
+      tar zxvf $package -C /usr/local
     )
   done
   set -x


### PR DESCRIPTION
Restructure the static archive staging directories to follow the
FHS-style bin/share/doc hierarchy.

- bin/<binary>
- share/doc/<pkgname>/LICENSE
- share/doc/<pkgname>/README.md

This allows users to extract directly into a prefix directory with no
extra steps:

tar -C /usr/local -xzf docker-buildx-linux-amd64.tgz

Previously, archives contained a single top-level named subdirectory
(e.g. docker-buildx/), so users had to either cd into it after
extraction or use --strip-components=1.