### PR TITLE
pkg/containerd: Rename static archive from containerd.io to containerd

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -586,7 +586,7 @@ target "_pkg-compose" {
 
 target "_pkg-containerd" {
   args = {
-    PKG_NAME = PKG_NAME != null && PKG_NAME != "" ? PKG_NAME : "containerd.io"
+    PKG_NAME = PKG_NAME != null && PKG_NAME != "" ? PKG_NAME : "containerd"
     PKG_REPO = PKG_REPO != null && PKG_REPO != "" ? PKG_REPO : "https://github.com/containerd/containerd.git"
     PKG_REF = PKG_REF != null && PKG_REF != "" ? PKG_REF : "release/2.2"
     GO_VERSION = GO_VERSION != null && GO_VERSION != "" ? GO_VERSION : "1.25.11" # https://github.com/containerd/containerd/blob/release/2.2/.github/workflows/release/Dockerfile

--- a/pkg/containerd/Dockerfile
+++ b/pkg/containerd/Dockerfile
@@ -29,7 +29,7 @@ ARG DISTRO_ID="12"
 ARG DISTRO_SUITE="bookworm"
 ARG DISTRO_IMAGE="debian:bookworm"
 
-ARG PKG_NAME="containerd.io"
+ARG PKG_NAME="containerd"
 ARG PKG_REPO="https://github.com/containerd/containerd.git"
 ARG PKG_REF="main"
 


### PR DESCRIPTION
The static tarballs were named containerd.io_<version>.tgz / .zip, matching the legacy Docker repository package name. The upstream project name is containerd, so rename the default PKG_NAME accordingly so that static archives are now named containerd_<version>.tgz / .zip.

The deb and rpm package names are unaffected.