### PR TITLE
static: Use hyphen as version separator in archive names

### DIFF
--- a/pkg/agent/scripts/pkg-static-build.sh
+++ b/pkg/agent/scripts/pkg-static-build.sh
@@ -79,12 +79,12 @@ for pkgname in *; do
     (
       set -x
       cd "$workdir/${pkgname}"
-      zip -r "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.zip" .
+      zip -r "${pkgoutput}/${pkgname}-${GENVER_VERSION#v}.zip" .
     )
   else
     (
       set -x
-      tar -czf "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.tgz" -C "$workdir/${pkgname}" .
+      tar -czf "${pkgoutput}/${pkgname}-${GENVER_VERSION#v}.tgz" -C "$workdir/${pkgname}" .
     )
   fi
 done

--- a/pkg/agent/scripts/pkg-static-build.sh
+++ b/pkg/agent/scripts/pkg-static-build.sh
@@ -78,13 +78,13 @@ for pkgname in *; do
   if [ "$(xx-info os)" = "windows" ]; then
     (
       set -x
-      cd "$workdir"
-      zip -r "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.zip" "${pkgname}"
+      cd "$workdir/${pkgname}"
+      zip -r "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.zip" .
     )
   else
     (
       set -x
-      tar -czf "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.tgz" -C "$workdir" "${pkgname}"
+      tar -czf "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.tgz" -C "$workdir/${pkgname}" .
     )
   fi
 done

--- a/pkg/buildx/scripts/pkg-static-build.sh
+++ b/pkg/buildx/scripts/pkg-static-build.sh
@@ -75,13 +75,13 @@ for pkgname in *; do
   if [ "$(xx-info os)" = "windows" ]; then
     (
       set -x
-      cd "$workdir"
-      zip -r "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.zip" "${pkgname}"
+      cd "$workdir/${pkgname}"
+      zip -r "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.zip" .
     )
   else
     (
       set -x
-      tar -czf "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.tgz" -C "$workdir" "${pkgname}"
+      tar -czf "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.tgz" -C "$workdir/${pkgname}" .
     )
   fi
 done

--- a/pkg/buildx/scripts/pkg-static-build.sh
+++ b/pkg/buildx/scripts/pkg-static-build.sh
@@ -76,12 +76,12 @@ for pkgname in *; do
     (
       set -x
       cd "$workdir/${pkgname}"
-      zip -r "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.zip" .
+      zip -r "${pkgoutput}/${pkgname}-${GENVER_VERSION#v}.zip" .
     )
   else
     (
       set -x
-      tar -czf "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.tgz" -C "$workdir/${pkgname}" .
+      tar -czf "${pkgoutput}/${pkgname}-${GENVER_VERSION#v}.tgz" -C "$workdir/${pkgname}" .
     )
   fi
 done

--- a/pkg/compose/scripts/pkg-static-build.sh
+++ b/pkg/compose/scripts/pkg-static-build.sh
@@ -81,12 +81,12 @@ for pkgname in *; do
     (
       set -x
       cd "$workdir/${pkgname}"
-      zip -r "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.zip" .
+      zip -r "${pkgoutput}/${pkgname}-${GENVER_VERSION#v}.zip" .
     )
   else
     (
       set -x
-      tar -czf "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.tgz" -C "$workdir/${pkgname}" .
+      tar -czf "${pkgoutput}/${pkgname}-${GENVER_VERSION#v}.tgz" -C "$workdir/${pkgname}" .
     )
   fi
 done

--- a/pkg/compose/scripts/pkg-static-build.sh
+++ b/pkg/compose/scripts/pkg-static-build.sh
@@ -80,13 +80,13 @@ for pkgname in *; do
   if [ "$(xx-info os)" = "windows" ]; then
     (
       set -x
-      cd "$workdir"
-      zip -r "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.zip" "${pkgname}"
+      cd "$workdir/${pkgname}"
+      zip -r "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.zip" .
     )
   else
     (
       set -x
-      tar -czf "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.tgz" -C "$workdir" "${pkgname}"
+      tar -czf "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.tgz" -C "$workdir/${pkgname}" .
     )
   fi
 done

--- a/pkg/containerd/scripts/pkg-static-build.sh
+++ b/pkg/containerd/scripts/pkg-static-build.sh
@@ -134,13 +134,13 @@ for pkgname in *; do
   if [ "$(xx-info os)" = "windows" ]; then
     (
       set -x
-      cd "$workdir"
-      zip -r "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.zip" "${pkgname}"
+      cd "$workdir/${pkgname}"
+      zip -r "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.zip" .
     )
   else
     (
       set -x
-      tar -czf "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.tgz" -C "$workdir" "${pkgname}"
+      tar -czf "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.tgz" -C "$workdir/${pkgname}" .
     )
   fi
 done

--- a/pkg/containerd/scripts/pkg-static-build.sh
+++ b/pkg/containerd/scripts/pkg-static-build.sh
@@ -135,12 +135,12 @@ for pkgname in *; do
     (
       set -x
       cd "$workdir/${pkgname}"
-      zip -r "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.zip" .
+      zip -r "${pkgoutput}/${pkgname}-${GENVER_VERSION#v}.zip" .
     )
   else
     (
       set -x
-      tar -czf "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.tgz" -C "$workdir/${pkgname}" .
+      tar -czf "${pkgoutput}/${pkgname}-${GENVER_VERSION#v}.tgz" -C "$workdir/${pkgname}" .
     )
   fi
 done

--- a/pkg/credential-helpers/scripts/pkg-static-build.sh
+++ b/pkg/credential-helpers/scripts/pkg-static-build.sh
@@ -102,13 +102,13 @@ for pkgname in *; do
   if [ "$(xx-info os)" = "windows" ]; then
     (
       set -x
-      cd "$workdir"
-      zip -r "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.zip" "${pkgname}"
+      cd "$workdir/${pkgname}"
+      zip -r "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.zip" .
     )
   else
     (
       set -x
-      tar -czf "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.tgz" -C "$workdir" "${pkgname}"
+      tar -czf "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.tgz" -C "$workdir/${pkgname}" .
     )
   fi
 done

--- a/pkg/credential-helpers/scripts/pkg-static-build.sh
+++ b/pkg/credential-helpers/scripts/pkg-static-build.sh
@@ -103,12 +103,12 @@ for pkgname in *; do
     (
       set -x
       cd "$workdir/${pkgname}"
-      zip -r "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.zip" .
+      zip -r "${pkgoutput}/${pkgname}-${GENVER_VERSION#v}.zip" .
     )
   else
     (
       set -x
-      tar -czf "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.tgz" -C "$workdir/${pkgname}" .
+      tar -czf "${pkgoutput}/${pkgname}-${GENVER_VERSION#v}.tgz" -C "$workdir/${pkgname}" .
     )
   fi
 done

--- a/pkg/docker-cli/scripts/pkg-static-build.sh
+++ b/pkg/docker-cli/scripts/pkg-static-build.sh
@@ -83,12 +83,12 @@ for pkgname in *; do
     (
       set -x
       cd "$workdir/${pkgname}"
-      zip -r "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.zip" .
+      zip -r "${pkgoutput}/${pkgname}-${GENVER_VERSION#v}.zip" .
     )
   else
     (
       set -x
-      tar -czf "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.tgz" -C "$workdir/${pkgname}" .
+      tar -czf "${pkgoutput}/${pkgname}-${GENVER_VERSION#v}.tgz" -C "$workdir/${pkgname}" .
     )
   fi
 done

--- a/pkg/docker-cli/scripts/pkg-static-build.sh
+++ b/pkg/docker-cli/scripts/pkg-static-build.sh
@@ -82,13 +82,13 @@ for pkgname in *; do
   if [ "$(xx-info os)" = "windows" ]; then
     (
       set -x
-      cd "$workdir"
-      zip -r "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.zip" "${pkgname}"
+      cd "$workdir/${pkgname}"
+      zip -r "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.zip" .
     )
   else
     (
       set -x
-      tar -czf "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.tgz" -C "$workdir" "${pkgname}"
+      tar -czf "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.tgz" -C "$workdir/${pkgname}" .
     )
   fi
 done

--- a/pkg/docker-engine/scripts/pkg-static-build.sh
+++ b/pkg/docker-engine/scripts/pkg-static-build.sh
@@ -101,12 +101,12 @@ for pkgname in *; do
     (
       set -x
       cd "$workdir/${pkgname}"
-      zip -r "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.zip" .
+      zip -r "${pkgoutput}/${pkgname}-${GENVER_VERSION#v}.zip" .
     )
   else
     (
       set -x
-      tar -czf "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.tgz" -C "$workdir/${pkgname}" .
+      tar -czf "${pkgoutput}/${pkgname}-${GENVER_VERSION#v}.tgz" -C "$workdir/${pkgname}" .
     )
   fi
 done

--- a/pkg/docker-engine/scripts/pkg-static-build.sh
+++ b/pkg/docker-engine/scripts/pkg-static-build.sh
@@ -100,13 +100,13 @@ for pkgname in *; do
   if [ "$(xx-info os)" = "windows" ]; then
     (
       set -x
-      cd "$workdir"
-      zip -r "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.zip" "${pkgname}"
+      cd "$workdir/${pkgname}"
+      zip -r "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.zip" .
     )
   else
     (
       set -x
-      tar -czf "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.tgz" -C "$workdir" "${pkgname}"
+      tar -czf "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.tgz" -C "$workdir/${pkgname}" .
     )
   fi
 done

--- a/pkg/model/scripts/pkg-static-build.sh
+++ b/pkg/model/scripts/pkg-static-build.sh
@@ -77,12 +77,12 @@ for pkgname in *; do
     (
       set -x
       cd "$workdir/${pkgname}"
-      zip -r "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.zip" .
+      zip -r "${pkgoutput}/${pkgname}-${GENVER_VERSION#v}.zip" .
     )
   else
     (
       set -x
-      tar -czf "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.tgz" -C "$workdir/${pkgname}" .
+      tar -czf "${pkgoutput}/${pkgname}-${GENVER_VERSION#v}.tgz" -C "$workdir/${pkgname}" .
     )
   fi
 done

--- a/pkg/model/scripts/pkg-static-build.sh
+++ b/pkg/model/scripts/pkg-static-build.sh
@@ -76,13 +76,13 @@ for pkgname in *; do
   if [ "$(xx-info os)" = "windows" ]; then
     (
       set -x
-      cd "$workdir"
-      zip -r "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.zip" "${pkgname}"
+      cd "$workdir/${pkgname}"
+      zip -r "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.zip" .
     )
   else
     (
       set -x
-      tar -czf "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.tgz" -C "$workdir" "${pkgname}"
+      tar -czf "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.tgz" -C "$workdir/${pkgname}" .
     )
   fi
 done


### PR DESCRIPTION
- needs: https://github.com/docker/packaging/pull/460

Change archive filenames from `pkgname_version` to `pkgname-version` (e.g. containerd-1.2.3.tgz instead of containerd_1.2.3.tgz) across all pkg-static-build.sh scripts.

This matches current download.docker.com naming