### PR TITLE
static: Don't ship READMEs in static archives

### DIFF
--- a/pkg/agent/scripts/pkg-static-build.sh
+++ b/pkg/agent/scripts/pkg-static-build.sh
@@ -73,7 +73,7 @@ for pkgname in *; do
   mkdir -p "$workdir/${pkgname}"
   (
     set -x
-    cp "${pkgname}"/* ${SRCDIR}/LICENSE ${SRCDIR}/README.md "$workdir/${pkgname}/"
+    cp "${pkgname}"/* ${SRCDIR}/LICENSE "$workdir/${pkgname}/"
   )
   if [ "$(xx-info os)" = "windows" ]; then
     (

--- a/pkg/buildx/scripts/pkg-static-build.sh
+++ b/pkg/buildx/scripts/pkg-static-build.sh
@@ -70,7 +70,7 @@ for pkgname in *; do
   mkdir -p "$workdir/${pkgname}"
   (
     set -x
-    cp "${pkgname}"/* ${SRCDIR}/LICENSE ${SRCDIR}/README.md "$workdir/${pkgname}/"
+    cp "${pkgname}"/* ${SRCDIR}/LICENSE "$workdir/${pkgname}/"
   )
   if [ "$(xx-info os)" = "windows" ]; then
     (

--- a/pkg/compose/scripts/pkg-static-build.sh
+++ b/pkg/compose/scripts/pkg-static-build.sh
@@ -75,7 +75,7 @@ for pkgname in *; do
   mkdir -p "$workdir/${pkgname}"
   (
     set -x
-    cp "${pkgname}"/* ${SRCDIR}/LICENSE ${SRCDIR}/README.md "$workdir/${pkgname}/"
+    cp "${pkgname}"/* ${SRCDIR}/LICENSE "$workdir/${pkgname}/"
   )
   if [ "$(xx-info os)" = "windows" ]; then
     (

--- a/pkg/containerd/scripts/pkg-static-build.sh
+++ b/pkg/containerd/scripts/pkg-static-build.sh
@@ -122,13 +122,11 @@ for pkgname in *; do
   mkdir -p "$workdir/${pkgname}"
   (
     set -x
-    cp "${pkgname}"/* ${SRCDIR}/LICENSE ${SRCDIR}/README.md "$workdir/${pkgname}/"
+    cp "${pkgname}"/* ${SRCDIR}/LICENSE "$workdir/${pkgname}/"
     if [ "$(xx-info os)" = "windows" ]; then
       cp ${RUNHCS_SRCDIR}/LICENSE "$workdir/${pkgname}/runhcs.LICENSE"
-      cp ${RUNHCS_SRCDIR}/README.md "$workdir/${pkgname}/runhcs.README.md"
     else
       cp ${RUNC_SRCDIR}/LICENSE "$workdir/${pkgname}/runc.LICENSE"
-      cp ${RUNC_SRCDIR}/README.md "$workdir/${pkgname}/runc.README.md"
     fi
   )
   if [ "$(xx-info os)" = "windows" ]; then

--- a/pkg/credential-helpers/scripts/pkg-static-build.sh
+++ b/pkg/credential-helpers/scripts/pkg-static-build.sh
@@ -97,7 +97,7 @@ for pkgname in *; do
   mkdir -p "$workdir/${pkgname}"
   (
     set -x
-    cp "${pkgname}"/* ${SRCDIR}/LICENSE ${SRCDIR}/README.md "$workdir/${pkgname}/"
+    cp "${pkgname}"/* ${SRCDIR}/LICENSE "$workdir/${pkgname}/"
   )
   if [ "$(xx-info os)" = "windows" ]; then
     (

--- a/pkg/docker-cli/scripts/pkg-static-build.sh
+++ b/pkg/docker-cli/scripts/pkg-static-build.sh
@@ -77,7 +77,7 @@ for pkgname in *; do
   mkdir -p "$workdir/${pkgname}"
   (
     set -x
-    cp "${pkgname}"/* ${SRCDIR}/LICENSE ${SRCDIR}/README.md "$workdir/${pkgname}/"
+    cp "${pkgname}"/* ${SRCDIR}/LICENSE "$workdir/${pkgname}/"
   )
   if [ "$(xx-info os)" = "windows" ]; then
     (

--- a/pkg/docker-engine/scripts/pkg-static-build.sh
+++ b/pkg/docker-engine/scripts/pkg-static-build.sh
@@ -95,7 +95,7 @@ for pkgname in *; do
   mkdir -p "$workdir/${pkgname}"
   (
     set -x
-    cp "${pkgname}"/* ${SRCDIR}/LICENSE ${SRCDIR}/README.md "$workdir/${pkgname}/"
+    cp "${pkgname}"/* ${SRCDIR}/LICENSE "$workdir/${pkgname}/"
   )
   if [ "$(xx-info os)" = "windows" ]; then
     (


### PR DESCRIPTION
Remove README.md from the files copied into static tarballs/zips across all packages. LICENSEs are kept; READMEs add no value to a binary release archive and just inflate the output.

For containerd, also drop the component-scoped runhcs.README.md and runc.README.md that were copied alongside the main project README.