### PR TITLE
Bump default containerd reference to release/2.3

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -588,8 +588,8 @@ target "_pkg-containerd" {
   args = {
     PKG_NAME = PKG_NAME != null && PKG_NAME != "" ? PKG_NAME : "containerd"
     PKG_REPO = PKG_REPO != null && PKG_REPO != "" ? PKG_REPO : "https://github.com/containerd/containerd.git"
-    PKG_REF = PKG_REF != null && PKG_REF != "" ? PKG_REF : "release/2.2"
-    GO_VERSION = GO_VERSION != null && GO_VERSION != "" ? GO_VERSION : "1.25.11" # https://github.com/containerd/containerd/blob/release/2.2/.github/workflows/release/Dockerfile
+    PKG_REF = PKG_REF != null && PKG_REF != "" ? PKG_REF : "release/2.3"
+    GO_VERSION = GO_VERSION != null && GO_VERSION != "" ? GO_VERSION : "1.26.4" # https://github.com/containerd/containerd/blob/release/2.3/.github/workflows/release/Dockerfile
     GO_IMAGE_VARIANT = GO_IMAGE_VARIANT != null && GO_IMAGE_VARIANT != "" ? GO_IMAGE_VARIANT : "bookworm"
     PKG_DEB_EPOCH = PKG_DEB_EPOCH != null && PKG_DEB_EPOCH != "" ? PKG_DEB_EPOCH : ""
     RUNC_REF = RUNC_REF != null && RUNC_REF != "" ? RUNC_REF : null


### PR DESCRIPTION
## Bump default containerd ref to release/2.3

### Why
The `_pkg-containerd` bake target still defaults to `PKG_REF = release/2.2` (currently
containerd v2.2.5). Upstream has since shipped the **v2.3** line (v2.3.0, v2.3.1, v2.3.2),
which is the new annual LTS branch. Nightly and default packaging builds should track the
current stable branch so v2.3.x packages can be produced.

### What changed
Two lines in `docker-bake.hcl`, target `_pkg-containerd`:
- `PKG_REF` default: `release/2.2` → `release/2.3`
- `GO_VERSION` default: `1.25.11` → `1.26.4` (matches containerd `release/2.3`
  `.github/workflows/release/Dockerfile`; comment link updated accordingly)

No other targets touched.

### How tested
- `docker buildx bake validate` — passes.
- Smoke build of `pkg-containerd-debian12` on the 2.3 ref (built `containerd.io` `.deb`
  with Go 1.26.4).
- RPM matrix `pkg-containerd-{rhel8,rhel9,rhel10}` + `verify-containerd-*` on the v2.3.2 ref
  (full results below).

### Related
Actual releases are cut by maintainers via the `release-containerd` `workflow_dispatch`
(`ref: vX.Y.Z`), not by this PR. A follow-up issue asking maintainers to dispatch v2.3.2
(and optionally back-fill v2.3.0/v2.3.1) is tracked in #467.

## Test results

RPM build + verify matrix for containerd v2.3.2 (host: darwin/arm64, build platform
`linux/arm64`; amd64 remains covered by CI):

| Version | Distro | pkg    | verify | pkg time | verify time |
|---------|--------|--------|--------|----------|-------------|
| v2.3.2  | rhel8  | PASS   | PASS   | 91s      | 58s         |
| v2.3.2  | rhel9  | PASS   | PASS   | 97s      | 21s         |
| v2.3.2  | rhel10 | PASS   | PASS   | 106s     | 23s         |
| v2.3.0  | rhel9  | PASS   | PASS   | 97s      | 20s (secondary spot-check) |
| v2.3.1  | rhel9  | PASS   | PASS   | 97s      | 21s (secondary spot-check) |

All 10 stages passed. The v2.3.2 RPM binary embeds the correct upstream revision `fff62f1`.

