### PR TITLE
ci: switch to docker/github-builder to build and sign

### DIFF
--- a/.github/workflows/.build.yml
+++ b/.github/workflows/.build.yml
@@ -7,7 +7,7 @@ on:
       name:
         required: true
         type: string
-      envs:
+      vars:
         required: false
         type: string
       release:
@@ -26,8 +26,6 @@ on:
         required: false
       dockerhub_token:
         required: false
-      ghtoken:
-        required: false
 
 env:
   REPO_SLUG: dockereng/packaging
@@ -39,6 +37,7 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       includes: ${{ steps.matrix.outputs.includes }}
+      verifications: ${{ steps.matrix.outputs.verifications }}
     steps:
       -
         name: Checkout
@@ -51,17 +50,17 @@ jobs:
           INPUT_NAME: ${{ inputs.name }}
           INPUT_RELEASE: ${{ inputs.release }}
           INPUT_DISTROS: ${{ inputs.distros }}
+          INPUT_VARS: ${{ inputs.vars }}
         with:
           script: |
             const inpName = core.getInput('name');
             const inpRelease = core.getInput('release');
             const inpDistros = core.getInput('distros');
+            const inpVars = core.getMultilineInput('vars');
+
             let distroFilter = [];
             if (inpDistros) {
-              distroFilter = inpDistros
-                .split(',')
-                .map(d => d.trim())
-                .filter(d => d !== '');
+              distroFilter = inpDistros.split(',').map(d => d.trim()).filter(d => d !== '');
             }
             
             if (inpRelease !== '' && !['pushonly', 'draft', 'prerelease', 'release'].includes(inpRelease)) {
@@ -70,7 +69,12 @@ jobs:
             
             let def = {};
             await core.group(`Parsing definition`, async () => {
-              const resPrint = await exec.getExecOutput('docker', ['buildx', 'bake', 'pkg', '--print'], {
+              const bakeArgs = ['buildx', 'bake'];
+              for (const v of inpVars) {
+                bakeArgs.push('--var', v);
+              }
+              bakeArgs.push('pkg', '--print');
+              const resPrint = await exec.getExecOutput('docker', bakeArgs, {
                 ignoreReturnCode: true
               });
               if (resPrint.stderr.length > 0 && resPrint.exitCode != 0) {
@@ -81,68 +85,96 @@ jobs:
             
             await core.group(`Generating matrix`, async () => {
               const includes = [];
+              const verifications = [];
               for (const targetName of Object.keys(def.target)) {
-                if (!targetName.startsWith(`pkg-${inpName}`)) {
+                if (!targetName.startsWith(`pkg-${inpName}-`)) {
                   continue;
                 }
                 const match = targetName.match(/^pkg-(.+)-([^-]+)$/);
                 if (!match) {
                   throw new Error(`Invalid target name: ${targetName}`);
                 }
-                const pkgName = match[1];
                 const distro = match[2];
-                // Skip distros that don't match the input distro filter
                 if (distroFilter.length > 0 && !distroFilter.includes(distro)) {
                   core.info(`Skipping ${targetName} because it doesn't match the input distro filter`);
                   continue;
                 }
                 const target = def.target[targetName];
                 if (target.platforms && target.platforms.length > 0) {
+                  includes.push({
+                    distro: distro
+                  });
                   target.platforms.forEach(platform => {
-                    includes.push({
-                      distro: distro,
-                      platform: platform,
-                      runner: platform.startsWith('linux/arm') ? 'ubuntu-24.04-arm' : 'ubuntu-24.04',
-                      // FIXME: we can't verify platforms not native to the runner as it would segfault through emulation
-                      verify: platform.startsWith('linux/386') || platform.startsWith('linux/amd64') || platform.startsWith('linux/arm64')
-                    });
+                    // FIXME: we can't verify platforms not native to the runner as it would segfault through emulation
+                    if (platform.startsWith('linux/386') || platform.startsWith('linux/amd64') || platform.startsWith('linux/arm64')) {
+                      verifications.push({
+                        distro: distro,
+                        platform: platform,
+                        runner: platform.startsWith('linux/arm') ? 'ubuntu-24.04-arm' : 'ubuntu-24.04'
+                      });
+                    }
                   });
                 } else {
                   // if no platforms are returned, this means this package does
                   // not support a distro so we skip it.
                 }
               }
+              if (includes.length === 0) {
+                throw new Error(`No package targets found for ${inpName}`);
+              }
               core.info(JSON.stringify(includes, null, 2));
+              core.info(JSON.stringify(verifications, null, 2));
               core.setOutput('includes', JSON.stringify(includes));
+              core.setOutput('verifications', JSON.stringify(verifications));
             });
 
+  # TODO: add RH_USER and RH_PASS to the build job once we have a way to pass secrets: https://github.com/docker/github-builder/pull/248
   build:
-    runs-on: ${{ matrix.runner }}
-    timeout-minutes: 60
+    uses: docker/github-builder/.github/workflows/bake.yml@3415a188caae9a0da7fba83bc06985776e0b1790 # v1.14.0
+    permissions:
+      contents: read
+      id-token: write
     needs:
       - prepare
-    env:
-      INPUT_ENVS: ${{ inputs.envs }}
-      INPUT_NAME: ${{ inputs.name }}
     strategy:
       fail-fast: false
       matrix:
         include: ${{ fromJson(needs.prepare.outputs.includes) }}
+    with:
+      job-name-prefix: ${{ matrix.distro }}
+      artifact-name: build-pkg-${{ inputs.name }}-${{ matrix.distro }}
+      artifact-upload: true
+      artifact-retention-days: 1
+      output: local
+      sbom: true
+      sign: ${{ github.event_name != 'pull_request' }}
+      target: pkg-${{ inputs.name }}-${{ matrix.distro }}
+      vars: |
+        ${{ inputs.vars }}
+
+  verify:
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 60
+    if: ${{ needs.prepare.outputs.verifications != '[]' }}
+    needs:
+      - prepare
+      - build
+    env:
+      INPUT_NAME: ${{ inputs.name }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.prepare.outputs.verifications) }}
     steps:
       -
         name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       -
-        name: Environment variables
-        run: |
-          if [ -n "$INPUT_ENVS" ]; then
-            printf '%s\n' "$INPUT_ENVS" >> "$GITHUB_ENV"
-          fi
-      -
-        name: Prepare
-        run: |
-          platform=${{ matrix.platform }}
-          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+        name: Download artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: build-pkg-${{ inputs.name }}-${{ matrix.distro }}
+          path: ./bin/pkg/${{ inputs.name }}/${{ matrix.distro }}
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
@@ -152,56 +184,35 @@ jobs:
         with:
           version: latest
       -
-        name: Build
-        uses: docker/bake-action@d3418bd7d0e9324001bca92fa8ba175ea7e6dc9b # v7.3.0
-        with:
-          source: .
-          targets: pkg-${{ inputs.name }}-${{ matrix.distro }}
-          set: |
-            *.platform=${{ matrix.platform }}
-        env:
-          RH_USER: ${{ secrets.rh_user }}
-          RH_PASS: ${{ secrets.rh_pass }}
-      -
         name: List artifacts
         run: |
           tree -nh "./bin/pkg/${INPUT_NAME}"
       -
         name: Verify
-        if: ${{ matrix.verify }}
         uses: docker/bake-action@d3418bd7d0e9324001bca92fa8ba175ea7e6dc9b # v7.3.0
         with:
           source: .
           targets: verify-${{ inputs.name }}-${{ matrix.distro }}
+          vars: |
+            ${{ inputs.vars }}
           set: |
             *.platform=${{ matrix.platform }}
-      -
-        name: Upload artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: build-pkg-${{ inputs.name }}-${{ matrix.distro }}-${{ env.PLATFORM_PAIR }}
-          path: ./bin/pkg/${{ inputs.name }}/*
-          if-no-files-found: error
-          retention-days: 1
 
   release:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
+    if: ${{ always() && needs.build.result == 'success' && (needs.verify.result == 'success' || needs.verify.result == 'skipped') }}
     needs:
+      - prepare
       - build
+      - verify
     env:
-      INPUT_ENVS: ${{ inputs.envs }}
+      INPUT_INCLUDES: ${{ needs.prepare.outputs.includes }}
       INPUT_NAME: ${{ inputs.name }}
     steps:
       -
         name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      -
-        name: Environment variables
-        run: |
-          if [ -n "$INPUT_ENVS" ]; then
-            printf '%s\n' "$INPUT_ENVS" >> "$GITHUB_ENV"
-          fi
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
@@ -211,9 +222,35 @@ jobs:
         name: Download artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          path: ./bin/pkg/${{ inputs.name }}
+          path: /tmp/build-pkg
           pattern: build-pkg-${{ inputs.name }}-*
-          merge-multiple: true
+          merge-multiple: false
+      -
+        name: Arrange artifacts
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          INPUT_INCLUDES: ${{ needs.prepare.outputs.includes }}
+          INPUT_NAME: ${{ inputs.name }}
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+
+            const inputName = core.getInput('name');
+            const includes = JSON.parse(core.getInput('includes'));
+            const destinationRoot = path.join('bin', 'pkg', inputName);
+
+            fs.mkdirSync(destinationRoot, {recursive: true});
+            for (const include of includes) {
+              const artifact = path.join('/tmp', 'build-pkg', `build-pkg-${inputName}-${include.distro}`);
+              if (!fs.existsSync(artifact) || !fs.statSync(artifact).isDirectory()) {
+                core.setFailed(`missing artifact: ${artifact}`);
+                return;
+              }
+              const destination = path.join(destinationRoot, include.distro);
+              fs.mkdirSync(destination, {recursive: true});
+              fs.cpSync(artifact, destination, {recursive: true, force: true});
+            }
       -
         name: List artifacts
         run: |
@@ -224,6 +261,8 @@ jobs:
         with:
           source: .
           targets: metadata-${{ inputs.name }}
+          vars: |
+            ${{ inputs.vars }}
           provenance: false
       -
         name: Resolve metadata
@@ -271,6 +310,8 @@ jobs:
             ${{ steps.meta.outputs.bake-file-tags }}
             ${{ steps.meta.outputs.bake-file-annotations }}
           targets: release-${{ inputs.name }}
+          vars: |
+            ${{ inputs.vars }}
           provenance: false
           set: |
             *.output=type=image,oci-mediatypes=true,push=${{ inputs.release != '' || github.event_name == 'schedule' }}
@@ -368,4 +409,4 @@ jobs:
             $ undock --wrap --rm-dist --all ${{ env.REPO_SLUG }}:${{ steps.meta.outputs.version }} ./${{ inputs.name }}/${{ env.VERSION }}
             ```
         env:
-          GITHUB_TOKEN: ${{ secrets.ghtoken || github.token }}
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/build-agent.yml
+++ b/.github/workflows/build-agent.yml
@@ -34,5 +34,6 @@ jobs:
     uses: ./.github/workflows/.build.yml
     permissions:
       contents: read
+      id-token: write
     with:
       name: agent

--- a/.github/workflows/build-buildx.yml
+++ b/.github/workflows/build-buildx.yml
@@ -34,5 +34,6 @@ jobs:
     uses: ./.github/workflows/.build.yml
     permissions:
       contents: read
+      id-token: write
     with:
       name: buildx

--- a/.github/workflows/build-compose.yml
+++ b/.github/workflows/build-compose.yml
@@ -34,5 +34,6 @@ jobs:
     uses: ./.github/workflows/.build.yml
     permissions:
       contents: read
+      id-token: write
     with:
       name: compose

--- a/.github/workflows/build-containerd.yml
+++ b/.github/workflows/build-containerd.yml
@@ -34,5 +34,6 @@ jobs:
     uses: ./.github/workflows/.build.yml
     permissions:
       contents: read
+      id-token: write
     with:
       name: containerd

--- a/.github/workflows/build-credential-helpers.yml
+++ b/.github/workflows/build-credential-helpers.yml
@@ -34,5 +34,6 @@ jobs:
     uses: ./.github/workflows/.build.yml
     permissions:
       contents: read
+      id-token: write
     with:
       name: credential-helpers

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -36,6 +36,7 @@ jobs:
     uses: ./.github/workflows/.build.yml
     permissions:
       contents: read
+      id-token: write
     with:
       name: docker-engine
 
@@ -43,5 +44,6 @@ jobs:
     uses: ./.github/workflows/.build.yml
     permissions:
       contents: read
+      id-token: write
     with:
       name: docker-cli

--- a/.github/workflows/build-model.yml
+++ b/.github/workflows/build-model.yml
@@ -34,5 +34,6 @@ jobs:
     uses: ./.github/workflows/.build.yml
     permissions:
       contents: read
+      id-token: write
     with:
       name: model

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,6 +21,7 @@ jobs:
     uses: ./.github/workflows/.build.yml
     permissions:
       contents: read
+      id-token: write
     needs:
       - pkgs
     strategy:
@@ -30,7 +31,7 @@ jobs:
     with:
       name: ${{ matrix.pkg }}
       release: pushonly
-      envs: |
+      vars: |
         NIGHTLY_BUILD=1
       dockerhub_username: ${{ vars.DOCKERPUBLICBOT_USERNAME }}
     secrets:

--- a/.github/workflows/release-agent.yml
+++ b/.github/workflows/release-agent.yml
@@ -46,11 +46,12 @@ jobs:
     uses: ./.github/workflows/.build.yml
     permissions:
       contents: write # needed to create release and upload artifacts
+      id-token: write # needed to sign attestations
     with:
       name: agent
       release: ${{ inputs.release }}
       distros: ${{ inputs.distros }}
-      envs: |
+      vars: |
         PKG_REPO=${{ inputs.repo }}
         PKG_REF=${{ inputs.ref }}
         PKG_DEB_REVISION=${{ inputs.revision }}

--- a/.github/workflows/release-buildx.yml
+++ b/.github/workflows/release-buildx.yml
@@ -46,11 +46,12 @@ jobs:
     uses: ./.github/workflows/.build.yml
     permissions:
       contents: write # needed to create release and upload artifacts
+      id-token: write # needed to sign attestations
     with:
       name: buildx
       release: ${{ inputs.release }}
       distros: ${{ inputs.distros }}
-      envs: |
+      vars: |
         PKG_REPO=${{ inputs.repo }}
         PKG_REF=${{ inputs.ref }}
         PKG_DEB_REVISION=${{ inputs.revision }}

--- a/.github/workflows/release-compose.yml
+++ b/.github/workflows/release-compose.yml
@@ -46,11 +46,12 @@ jobs:
     uses: ./.github/workflows/.build.yml
     permissions:
       contents: write # needed to create release and upload artifacts
+      id-token: write # needed to sign attestations
     with:
       name: compose
       release: ${{ inputs.release }}
       distros: ${{ inputs.distros }}
-      envs: |
+      vars: |
         PKG_REPO=${{ inputs.repo }}
         PKG_REF=${{ inputs.ref }}
         PKG_DEB_REVISION=${{ inputs.revision }}

--- a/.github/workflows/release-containerd.yml
+++ b/.github/workflows/release-containerd.yml
@@ -56,11 +56,12 @@ jobs:
     uses: ./.github/workflows/.build.yml
     permissions:
       contents: write # needed to create release and upload artifacts
+      id-token: write # needed to sign attestations
     with:
       name: containerd
       release: ${{ inputs.release }}
       distros: ${{ inputs.distros }}
-      envs: |
+      vars: |
         PKG_REPO=${{ inputs.repo }}
         PKG_REF=${{ inputs.ref }}
         PKG_DEB_REVISION=${{ inputs.revision }}

--- a/.github/workflows/release-credential-helpers.yml
+++ b/.github/workflows/release-credential-helpers.yml
@@ -46,11 +46,12 @@ jobs:
     uses: ./.github/workflows/.build.yml
     permissions:
       contents: write # needed to create release and upload artifacts
+      id-token: write # needed to sign attestations
     with:
       name: credential-helpers
       release: ${{ inputs.release }}
       distros: ${{ inputs.distros }}
-      envs: |
+      vars: |
         PKG_REPO=${{ inputs.repo }}
         PKG_REF=${{ inputs.ref }}
         PKG_DEB_REVISION=${{ inputs.revision }}

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -58,11 +58,12 @@ jobs:
     uses: ./.github/workflows/.build.yml
     permissions:
       contents: write # needed to create release and upload artifacts
+      id-token: write # needed to sign attestations
     with:
       name: docker-engine
       release: ${{ inputs.release }}
       distros: ${{ inputs.distros }}
-      envs: |
+      vars: |
         PKG_REPO=${{ inputs.engine-repo }}
         PKG_REF=${{ inputs.engine-ref }}
         PKG_DEB_REVISION=${{ inputs.revision }}
@@ -77,11 +78,12 @@ jobs:
     uses: ./.github/workflows/.build.yml
     permissions:
       contents: write # needed to create release and upload artifacts
+      id-token: write # needed to sign attestations
     with:
       name: docker-cli
       release: ${{ inputs.release }}
       distros: ${{ inputs.distros }}
-      envs: |
+      vars: |
         PKG_REPO=${{ inputs.cli-repo }}
         PKG_REF=${{ inputs.cli-ref }}
         PKG_DEB_REVISION=${{ inputs.revision }}

--- a/.github/workflows/release-model.yml
+++ b/.github/workflows/release-model.yml
@@ -46,11 +46,12 @@ jobs:
     uses: ./.github/workflows/.build.yml
     permissions:
       contents: write # needed to create release and upload artifacts
+      id-token: write # needed to sign attestations
     with:
       name: model
       release: ${{ inputs.release }}
       distros: ${{ inputs.distros }}
-      envs: |
+      vars: |
         PKG_REPO=${{ inputs.repo }}
         PKG_REF=${{ inputs.ref }}
         PKG_DEB_REVISION=${{ inputs.revision }}

--- a/hack/release.Dockerfile
+++ b/hack/release.Dockerfile
@@ -49,7 +49,10 @@ RUN --mount=from=bin,source=.,target=/release <<EOT
         mkdir -p "/out/${relpdir}"
         cp "${pdir}"/* "/out/${relpdir}/"
         cp ${f}/${basedir}/sbom-build*.json "/out/${relpdir}/sbom.json"
-        cp "${f}/${basedir}/provenance.json" "/out/${relpdir}/provenance.json"
+        cp "${f}/${basedir}/provenance.json" "/out/${relpdir}/"
+        if [ -f "${f}/${basedir}/provenance.sigstore.json" ]; then
+          cp "${f}/${basedir}/provenance.sigstore.json" "/out/${relpdir}/"
+        fi
       )
     done
   done

--- a/hack/release.Dockerfile
+++ b/hack/release.Dockerfile
@@ -48,11 +48,18 @@ RUN --mount=from=bin,source=.,target=/release <<EOT
         set -x
         mkdir -p "/out/${relpdir}"
         cp "${pdir}"/* "/out/${relpdir}/"
-        cp ${f}/${basedir}/sbom-build*.json "/out/${relpdir}/sbom.json"
-        cp "${f}/${basedir}/provenance.json" "/out/${relpdir}/"
-        if [ -f "${f}/${basedir}/provenance.sigstore.json" ]; then
-          cp "${f}/${basedir}/provenance.sigstore.json" "/out/${relpdir}/"
-        fi
+        for package in "${pdir}"/*.deb "${pdir}"/*.rpm "${pdir}"/*.tgz "${pdir}"/*.zip; do
+          if [ ! -f "$package" ]; then
+            continue
+          fi
+          package_name="${package##*/}"
+          package_name="${package_name%.*}"
+          cp ${f}/${basedir}/sbom-build*.json "/out/${relpdir}/${package_name}.sbom.json"
+          cp "${f}/${basedir}/provenance.json" "/out/${relpdir}/${package_name}.provenance.json"
+          if [ -f "${f}/${basedir}/provenance.sigstore.json" ]; then
+            cp "${f}/${basedir}/provenance.sigstore.json" "/out/${relpdir}/${package_name}.sigstore.json"
+          fi
+        done
       )
     done
   done


### PR DESCRIPTION
This PR moves package builds onto `docker/github-builder` and keeps the release image layout aligned with the signed metadata that the builder now produces. Builds now publish package artifacts with signed provenance and Sigstore bundle material.

The first commit reworks the reusable build workflow so each distro package build is delegated to `docker/github-builder`, with Bake variables passed through the workflow input and package verification kept in this repository. The second commit updates `hack/release.Dockerfile` so release metadata files are emitted next to each package using the package artifact basename, such as:
* `docker-buildx-plugin-0.35.0-1.el10.x86_64.provenance.json`
* `docker-buildx-plugin-0.35.0-1.el10.x86_64.sigstore.json`
* `docker-buildx-plugin-0.35.0-1.el10.x86_64.sbom.json`

Using `docker/github-builder` centralizes runner handling, SBOM generation, provenance generation, and OIDC-backed signing instead of carrying that logic in the packaging workflow. Naming release metadata after the package artifact makes the release image easier to consume because every SBOM, provenance file, and Sigstore bundle is tied directly to the package it describes.

Package builds now enable signing outside pull requests, which causes the builder to produce signed provenance and Sigstore verification material for the package artifacts. This gives release consumers a clear path from the package file to its SBOM, provenance, and signature bundle without relying on shared generic filenames in each release directory.

A follow-up should look at appending the Sigstore bundle directly into the package artifacts themselves. Keeping the bundle next to the packages is a good first step, but embedding or attaching the verification material at the package format level would make distribution and verification less dependent on external sidecar files.