### PR TITLE
update to alpine 3.22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG ALPINE_VERSION=3.22
+ARG ALPINE_VERSION=3.23
 ARG ADDLICENSE_VERSION=1.0.0
 
 ARG LICENSE_TYPE="apache"

--- a/hack/release.Dockerfile
+++ b/hack/release.Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG ALPINE_VERSION="3.22"
+ARG ALPINE_VERSION="3.23"
 
 FROM scratch AS bin
 


### PR DESCRIPTION
Official images now use alpine 3.24 as a default, and removed alpine 3.22 variants of base images; let's align with those.