### PR TITLE
docker-cli: avoid duplicate static archive binary

### DIFF
--- a/pkg/docker-cli/scripts/pkg-static-build.sh
+++ b/pkg/docker-cli/scripts/pkg-static-build.sh
@@ -57,6 +57,9 @@ if [  "$(xx-info arch)" = "arm64" ]; then
   XX_CC_PREFER_LINKER=ld xx-clang --setup-target-triple
 fi
 
+binext=$([ "$(xx-info os)" = "windows" ] && echo ".exe" || true)
+clibin="docker${binext}"
+
 (
   set -x
   pushd ${SRCDIR}
@@ -77,7 +80,8 @@ for pkgname in *; do
   mkdir -p "$workdir/${pkgname}"
   (
     set -x
-    cp "${pkgname}"/* ${SRCDIR}/LICENSE ${SRCDIR}/README.md "$workdir/${pkgname}/"
+    cp -L "${pkgname}/docker" "$workdir/${pkgname}/${clibin}"
+    cp ${SRCDIR}/LICENSE ${SRCDIR}/README.md "$workdir/${pkgname}/"
   )
   if [ "$(xx-info os)" = "windows" ]; then
     (


### PR DESCRIPTION
The Docker CLI static archive now includes only the canonical `docker` binary instead of packaging both `docker` and the platform-specific build output that it points to. This keeps the archive contents smaller and less surprising while preserving the executable users expect after extraction.