### PR TITLE
static: add checksum files for package archives

### DIFF
--- a/hack/scripts/write-sha256sum.sh
+++ b/hack/scripts/write-sha256sum.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 Docker Packaging authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+if [ "$#" -ne 1 ]; then
+  echo >&2 "usage: write-sha256sum <file>"
+  exit 1
+fi
+
+file="$1"
+case "$file" in
+  */*)
+    dir="${file%/*}"
+    name="${file##*/}"
+    ;;
+  *)
+    dir=.
+    name="$file"
+    ;;
+esac
+
+(
+  set -x
+  cd "$dir"
+  sha256sum "$name" > "${name}.sha256"
+)

--- a/pkg/agent/Dockerfile
+++ b/pkg/agent/Dockerfile
@@ -192,6 +192,7 @@ ARG TARGETPLATFORM
 RUN --mount=type=bind,source=scripts/pkg-static-build.sh,target=/usr/local/bin/pkg-static-build \
     --mount=type=bind,from=scripts,source=gen-ver.sh,target=/usr/local/bin/gen-ver \
     --mount=type=bind,from=scripts,source=fix-cc.sh,target=/usr/local/bin/fix-cc \
+    --mount=type=bind,from=scripts,source=write-sha256sum.sh,target=/usr/local/bin/write-sha256sum \
     --mount=type=bind,from=src,source=/src,target=/usr/local/src/agent \
     --mount=type=bind,from=gocross,source=/usr/local/go,target=/usr/local/go,rw \
     --mount=type=bind,from=osxcross,src=/osxsdk,target=/xx-sdk \

--- a/pkg/agent/scripts/pkg-static-build.sh
+++ b/pkg/agent/scripts/pkg-static-build.sh
@@ -76,15 +76,22 @@ for pkgname in *; do
     cp "${pkgname}"/* ${SRCDIR}/LICENSE ${SRCDIR}/README.md "$workdir/${pkgname}/"
   )
   if [ "$(xx-info os)" = "windows" ]; then
+    pkgfile="${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.zip"
     (
       set -x
       cd "$workdir"
-      zip -r "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.zip" "${pkgname}"
+      zip -r "$pkgfile" "${pkgname}"
     )
   else
+    pkgfile="${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.tgz"
     (
       set -x
-      tar -czf "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.tgz" -C "$workdir" "${pkgname}"
+      tar -czf "$pkgfile" -C "$workdir" "${pkgname}"
     )
   fi
+  (
+    set -x
+    cd "$pkgoutput"
+    sha256sum "${pkgfile##*/}" > "${pkgfile##*/}.sha256"
+  )
 done

--- a/pkg/agent/scripts/pkg-static-build.sh
+++ b/pkg/agent/scripts/pkg-static-build.sh
@@ -89,9 +89,5 @@ for pkgname in *; do
       tar -czf "$pkgfile" -C "$workdir" "${pkgname}"
     )
   fi
-  (
-    set -x
-    cd "$pkgoutput"
-    sha256sum "${pkgfile##*/}" > "${pkgfile##*/}.sha256"
-  )
+  write-sha256sum "$pkgfile"
 done

--- a/pkg/agent/verify.Dockerfile
+++ b/pkg/agent/verify.Dockerfile
@@ -108,7 +108,9 @@ RUN --mount=from=bin,target=/build <<EOT
   for package in $(find $dir -type f -name '*.tgz'); do
     (
       set -x
-      tar zxvf $package -C /usr/bin --strip-components=1
+      cd "${package%/*}"
+      sha256sum -c "${package##*/}.sha256"
+      tar zxvf "${package##*/}" -C /usr/bin --strip-components=1
     )
   done
   set -x

--- a/pkg/buildx/Dockerfile
+++ b/pkg/buildx/Dockerfile
@@ -169,6 +169,7 @@ ARG TARGETPLATFORM
 RUN --mount=type=bind,source=scripts/pkg-static-build.sh,target=/usr/local/bin/pkg-static-build \
     --mount=type=bind,from=scripts,source=gen-ver.sh,target=/usr/local/bin/gen-ver \
     --mount=type=bind,from=scripts,source=fix-cc.sh,target=/usr/local/bin/fix-cc \
+    --mount=type=bind,from=scripts,source=write-sha256sum.sh,target=/usr/local/bin/write-sha256sum \
     --mount=type=bind,from=src,source=/src,target=/usr/local/src/buildx \
     --mount=type=bind,from=gocross,source=/usr/local/go,target=/usr/local/go,rw \
     OUTDIR=/out BUILDDIR=/build SRCDIR=/usr/local/src/buildx pkg-static-build

--- a/pkg/buildx/scripts/pkg-static-build.sh
+++ b/pkg/buildx/scripts/pkg-static-build.sh
@@ -86,9 +86,5 @@ for pkgname in *; do
       tar -czf "$pkgfile" -C "$workdir" "${pkgname}"
     )
   fi
-  (
-    set -x
-    cd "$pkgoutput"
-    sha256sum "${pkgfile##*/}" > "${pkgfile##*/}.sha256"
-  )
+  write-sha256sum "$pkgfile"
 done

--- a/pkg/buildx/scripts/pkg-static-build.sh
+++ b/pkg/buildx/scripts/pkg-static-build.sh
@@ -73,15 +73,22 @@ for pkgname in *; do
     cp "${pkgname}"/* ${SRCDIR}/LICENSE ${SRCDIR}/README.md "$workdir/${pkgname}/"
   )
   if [ "$(xx-info os)" = "windows" ]; then
+    pkgfile="${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.zip"
     (
       set -x
       cd "$workdir"
-      zip -r "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.zip" "${pkgname}"
+      zip -r "$pkgfile" "${pkgname}"
     )
   else
+    pkgfile="${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.tgz"
     (
       set -x
-      tar -czf "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.tgz" -C "$workdir" "${pkgname}"
+      tar -czf "$pkgfile" -C "$workdir" "${pkgname}"
     )
   fi
+  (
+    set -x
+    cd "$pkgoutput"
+    sha256sum "${pkgfile##*/}" > "${pkgfile##*/}.sha256"
+  )
 done

--- a/pkg/buildx/verify.Dockerfile
+++ b/pkg/buildx/verify.Dockerfile
@@ -108,7 +108,9 @@ RUN --mount=from=bin,target=/build <<EOT
   for package in $(find $dir -type f -name '*.tgz'); do
     (
       set -x
-      tar zxvf $package -C /usr/bin --strip-components=1
+      cd "${package%/*}"
+      sha256sum -c "${package##*/}.sha256"
+      tar zxvf "${package##*/}" -C /usr/bin --strip-components=1
     )
   done
   set -x

--- a/pkg/compose/Dockerfile
+++ b/pkg/compose/Dockerfile
@@ -180,6 +180,7 @@ RUN xx-apt-get install -y gcc libc6-dev
 RUN --mount=type=bind,source=scripts/pkg-static-build.sh,target=/usr/local/bin/pkg-static-build \
     --mount=type=bind,from=scripts,source=gen-ver.sh,target=/usr/local/bin/gen-ver \
     --mount=type=bind,from=scripts,source=fix-cc.sh,target=/usr/local/bin/fix-cc \
+    --mount=type=bind,from=scripts,source=write-sha256sum.sh,target=/usr/local/bin/write-sha256sum \
     --mount=type=bind,from=src,source=/src,target=/usr/local/src/compose \
     --mount=type=bind,from=gocross,source=/usr/local/go,target=/usr/local/go,rw \
     OUTDIR=/out BUILDDIR=/build SRCDIR=/usr/local/src/compose pkg-static-build
@@ -211,6 +212,7 @@ RUN xx-apt-get install -y gcc libc6-dev
 RUN --mount=type=bind,source=scripts/pkg-static-build.sh,target=/usr/local/bin/pkg-static-build \
     --mount=type=bind,from=scripts,source=gen-ver.sh,target=/usr/local/bin/gen-ver \
     --mount=type=bind,from=scripts,source=fix-cc.sh,target=/usr/local/bin/fix-cc \
+    --mount=type=bind,from=scripts,source=write-sha256sum.sh,target=/usr/local/bin/write-sha256sum \
     --mount=type=bind,from=src,source=/src,target=/usr/local/src/compose \
     --mount=type=bind,from=gocross,source=/usr/local/go,target=/usr/local/go,rw \
     --mount=type=bind,from=osxcross,src=/osxsdk,target=/xx-sdk \

--- a/pkg/compose/scripts/pkg-static-build.sh
+++ b/pkg/compose/scripts/pkg-static-build.sh
@@ -91,9 +91,5 @@ for pkgname in *; do
       tar -czf "$pkgfile" -C "$workdir" "${pkgname}"
     )
   fi
-  (
-    set -x
-    cd "$pkgoutput"
-    sha256sum "${pkgfile##*/}" > "${pkgfile##*/}.sha256"
-  )
+  write-sha256sum "$pkgfile"
 done

--- a/pkg/compose/scripts/pkg-static-build.sh
+++ b/pkg/compose/scripts/pkg-static-build.sh
@@ -78,15 +78,22 @@ for pkgname in *; do
     cp "${pkgname}"/* ${SRCDIR}/LICENSE ${SRCDIR}/README.md "$workdir/${pkgname}/"
   )
   if [ "$(xx-info os)" = "windows" ]; then
+    pkgfile="${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.zip"
     (
       set -x
       cd "$workdir"
-      zip -r "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.zip" "${pkgname}"
+      zip -r "$pkgfile" "${pkgname}"
     )
   else
+    pkgfile="${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.tgz"
     (
       set -x
-      tar -czf "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.tgz" -C "$workdir" "${pkgname}"
+      tar -czf "$pkgfile" -C "$workdir" "${pkgname}"
     )
   fi
+  (
+    set -x
+    cd "$pkgoutput"
+    sha256sum "${pkgfile##*/}" > "${pkgfile##*/}.sha256"
+  )
 done

--- a/pkg/compose/verify.Dockerfile
+++ b/pkg/compose/verify.Dockerfile
@@ -108,7 +108,9 @@ RUN --mount=from=bin,target=/build <<EOT
   for package in $(find $dir -type f -name '*.tgz'); do
     (
       set -x
-      tar zxvf $package -C /usr/bin --strip-components=1
+      cd "${package%/*}"
+      sha256sum -c "${package##*/}.sha256"
+      tar zxvf "${package##*/}" -C /usr/bin --strip-components=1
     )
   done
   set -x

--- a/pkg/containerd/Dockerfile
+++ b/pkg/containerd/Dockerfile
@@ -260,6 +260,7 @@ RUN xx-apt-get install -y gcc
 RUN --mount=type=bind,source=scripts/pkg-static-build.sh,target=/usr/local/bin/pkg-static-build \
     --mount=type=bind,from=scripts,source=gen-ver.sh,target=/usr/local/bin/gen-ver \
     --mount=type=bind,from=scripts,source=fix-cc.sh,target=/usr/local/bin/fix-cc \
+    --mount=type=bind,from=scripts,source=write-sha256sum.sh,target=/usr/local/bin/write-sha256sum \
     --mount=type=bind,from=src,source=/src,target=/go/src/github.com/containerd/containerd,rw \
     --mount=type=bind,from=runc-src,source=/src,target=/go/src/github.com/opencontainers/runc,rw \
     --mount=type=bind,from=runhcs-src,source=/src,target=/go/src/github.com/Microsoft/hcsshim,rw \

--- a/pkg/containerd/scripts/pkg-static-build.sh
+++ b/pkg/containerd/scripts/pkg-static-build.sh
@@ -132,15 +132,22 @@ for pkgname in *; do
     fi
   )
   if [ "$(xx-info os)" = "windows" ]; then
+    pkgfile="${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.zip"
     (
       set -x
       cd "$workdir"
-      zip -r "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.zip" "${pkgname}"
+      zip -r "$pkgfile" "${pkgname}"
     )
   else
+    pkgfile="${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.tgz"
     (
       set -x
-      tar -czf "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.tgz" -C "$workdir" "${pkgname}"
+      tar -czf "$pkgfile" -C "$workdir" "${pkgname}"
     )
   fi
+  (
+    set -x
+    cd "$pkgoutput"
+    sha256sum "${pkgfile##*/}" > "${pkgfile##*/}.sha256"
+  )
 done

--- a/pkg/containerd/scripts/pkg-static-build.sh
+++ b/pkg/containerd/scripts/pkg-static-build.sh
@@ -145,9 +145,5 @@ for pkgname in *; do
       tar -czf "$pkgfile" -C "$workdir" "${pkgname}"
     )
   fi
-  (
-    set -x
-    cd "$pkgoutput"
-    sha256sum "${pkgfile##*/}" > "${pkgfile##*/}.sha256"
-  )
+  write-sha256sum "$pkgfile"
 done

--- a/pkg/containerd/verify.Dockerfile
+++ b/pkg/containerd/verify.Dockerfile
@@ -112,7 +112,9 @@ RUN --mount=from=bin,target=/build <<EOT
   for package in $(find $dir -type f -name '*.tgz'); do
     (
       set -x
-      tar zxvf $package -C /usr/bin --strip-components=1
+      cd "${package%/*}"
+      sha256sum -c "${package##*/}.sha256"
+      tar zxvf "${package##*/}" -C /usr/bin --strip-components=1
     )
   done
   set -x

--- a/pkg/credential-helpers/Dockerfile
+++ b/pkg/credential-helpers/Dockerfile
@@ -173,6 +173,7 @@ RUN xx-apt-get install -y gcc libsecret-1-dev
 RUN --mount=type=bind,source=scripts/pkg-static-build.sh,target=/usr/local/bin/pkg-static-build \
     --mount=type=bind,from=scripts,source=gen-ver.sh,target=/usr/local/bin/gen-ver \
     --mount=type=bind,from=scripts,source=fix-cc.sh,target=/usr/local/bin/fix-cc \
+    --mount=type=bind,from=scripts,source=write-sha256sum.sh,target=/usr/local/bin/write-sha256sum \
     --mount=type=bind,from=src,source=/src,target=/usr/local/src/credential-helpers \
     --mount=type=bind,from=gocross,source=/usr/local/go,target=/usr/local/go,rw \
     OUTDIR=/out BUILDDIR=/build SRCDIR=/usr/local/src/credential-helpers pkg-static-build
@@ -198,6 +199,7 @@ RUN xx-apt-get install -y gcc libsecret-1-dev
 RUN --mount=type=bind,source=scripts/pkg-static-build.sh,target=/usr/local/bin/pkg-static-build \
     --mount=type=bind,from=scripts,source=gen-ver.sh,target=/usr/local/bin/gen-ver \
     --mount=type=bind,from=scripts,source=fix-cc.sh,target=/usr/local/bin/fix-cc \
+    --mount=type=bind,from=scripts,source=write-sha256sum.sh,target=/usr/local/bin/write-sha256sum \
     --mount=type=bind,from=src,source=/src,target=/usr/local/src/credential-helpers \
     --mount=type=bind,from=gocross,source=/usr/local/go,target=/usr/local/go,rw \
     --mount=type=bind,from=osxcross,src=/osxsdk,target=/xx-sdk \

--- a/pkg/credential-helpers/scripts/pkg-static-build.sh
+++ b/pkg/credential-helpers/scripts/pkg-static-build.sh
@@ -113,9 +113,5 @@ for pkgname in *; do
       tar -czf "$pkgfile" -C "$workdir" "${pkgname}"
     )
   fi
-  (
-    set -x
-    cd "$pkgoutput"
-    sha256sum "${pkgfile##*/}" > "${pkgfile##*/}.sha256"
-  )
+  write-sha256sum "$pkgfile"
 done

--- a/pkg/credential-helpers/scripts/pkg-static-build.sh
+++ b/pkg/credential-helpers/scripts/pkg-static-build.sh
@@ -100,15 +100,22 @@ for pkgname in *; do
     cp "${pkgname}"/* ${SRCDIR}/LICENSE ${SRCDIR}/README.md "$workdir/${pkgname}/"
   )
   if [ "$(xx-info os)" = "windows" ]; then
+    pkgfile="${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.zip"
     (
       set -x
       cd "$workdir"
-      zip -r "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.zip" "${pkgname}"
+      zip -r "$pkgfile" "${pkgname}"
     )
   else
+    pkgfile="${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.tgz"
     (
       set -x
-      tar -czf "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.tgz" -C "$workdir" "${pkgname}"
+      tar -czf "$pkgfile" -C "$workdir" "${pkgname}"
     )
   fi
+  (
+    set -x
+    cd "$pkgoutput"
+    sha256sum "${pkgfile##*/}" > "${pkgfile##*/}.sha256"
+  )
 done

--- a/pkg/credential-helpers/verify.Dockerfile
+++ b/pkg/credential-helpers/verify.Dockerfile
@@ -121,7 +121,9 @@ RUN --mount=from=bin,target=/build <<EOT
   for package in $(find $dir -type f -name '*.tgz'); do
     (
       set -x
-      tar zxvf $package -C /usr/bin --strip-components=1
+      cd "${package%/*}"
+      sha256sum -c "${package##*/}.sha256"
+      tar zxvf "${package##*/}" -C /usr/bin --strip-components=1
     )
   done
   set -x

--- a/pkg/docker-cli/Dockerfile
+++ b/pkg/docker-cli/Dockerfile
@@ -193,6 +193,7 @@ RUN xx-apt-get install -y gcc libc6-dev
 RUN --mount=type=bind,source=scripts/pkg-static-build.sh,target=/usr/local/bin/pkg-static-build \
     --mount=type=bind,from=scripts,source=gen-ver.sh,target=/usr/local/bin/gen-ver \
     --mount=type=bind,from=scripts,source=fix-cc.sh,target=/usr/local/bin/fix-cc \
+    --mount=type=bind,from=scripts,source=write-sha256sum.sh,target=/usr/local/bin/write-sha256sum \
     --mount=type=bind,from=src,source=/src,target=/go/src/github.com/docker/cli,rw \
     --mount=type=bind,from=gocross,source=/usr/local/go,target=/usr/local/go,rw \
     --mount=type=bind,from=goversioninfo,source=/out/goversioninfo,target=/usr/bin/goversioninfo \
@@ -212,6 +213,7 @@ RUN xx-apt-get install -y gcc libc6-dev
 RUN --mount=type=bind,source=scripts/pkg-static-build.sh,target=/usr/local/bin/pkg-static-build \
     --mount=type=bind,from=scripts,source=gen-ver.sh,target=/usr/local/bin/gen-ver \
     --mount=type=bind,from=scripts,source=fix-cc.sh,target=/usr/local/bin/fix-cc \
+    --mount=type=bind,from=scripts,source=write-sha256sum.sh,target=/usr/local/bin/write-sha256sum \
     --mount=type=bind,from=src,source=/src,target=/go/src/github.com/docker/cli,rw \
     --mount=type=bind,from=gocross,source=/usr/local/go,target=/usr/local/go,rw \
     --mount=type=bind,from=goversioninfo,source=/out/goversioninfo,target=/usr/bin/goversioninfo \

--- a/pkg/docker-cli/scripts/pkg-static-build.sh
+++ b/pkg/docker-cli/scripts/pkg-static-build.sh
@@ -84,15 +84,22 @@ for pkgname in *; do
     cp ${SRCDIR}/LICENSE ${SRCDIR}/README.md "$workdir/${pkgname}/"
   )
   if [ "$(xx-info os)" = "windows" ]; then
+    pkgfile="${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.zip"
     (
       set -x
       cd "$workdir"
-      zip -r "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.zip" "${pkgname}"
+      zip -r "$pkgfile" "${pkgname}"
     )
   else
+    pkgfile="${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.tgz"
     (
       set -x
-      tar -czf "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.tgz" -C "$workdir" "${pkgname}"
+      tar -czf "$pkgfile" -C "$workdir" "${pkgname}"
     )
   fi
+  (
+    set -x
+    cd "$pkgoutput"
+    sha256sum "${pkgfile##*/}" > "${pkgfile##*/}.sha256"
+  )
 done

--- a/pkg/docker-cli/scripts/pkg-static-build.sh
+++ b/pkg/docker-cli/scripts/pkg-static-build.sh
@@ -97,9 +97,5 @@ for pkgname in *; do
       tar -czf "$pkgfile" -C "$workdir" "${pkgname}"
     )
   fi
-  (
-    set -x
-    cd "$pkgoutput"
-    sha256sum "${pkgfile##*/}" > "${pkgfile##*/}.sha256"
-  )
+  write-sha256sum "$pkgfile"
 done

--- a/pkg/docker-cli/verify.Dockerfile
+++ b/pkg/docker-cli/verify.Dockerfile
@@ -108,7 +108,9 @@ RUN --mount=from=bin,target=/build <<EOT
   for package in $(find $dir -type f -name '*.tgz'); do
     (
       set -x
-      tar zxvf $package -C /usr/bin --strip-components=1
+      cd "${package%/*}"
+      sha256sum -c "${package##*/}.sha256"
+      tar zxvf "${package##*/}" -C /usr/bin --strip-components=1
     )
   done
   set -x

--- a/pkg/docker-engine/Dockerfile
+++ b/pkg/docker-engine/Dockerfile
@@ -208,6 +208,7 @@ RUN --mount=type=bind,source=scripts/pkg-static-build.sh,target=/usr/local/bin/p
     --mount=type=bind,source=scripts/check-gomod.sh,target=/usr/local/bin/check-gomod \
     --mount=type=bind,from=scripts,source=gen-ver.sh,target=/usr/local/bin/gen-ver \
     --mount=type=bind,from=scripts,source=fix-cc.sh,target=/usr/local/bin/fix-cc \
+    --mount=type=bind,from=scripts,source=write-sha256sum.sh,target=/usr/local/bin/write-sha256sum \
     --mount=type=bind,from=src,source=/src,target=/go/src/github.com/docker/docker,rw \
     --mount=type=bind,from=gocross,source=/usr/local/go,target=/usr/local/go,rw \
     --mount=type=bind,from=gowinres,source=/out/go-winres,target=/usr/bin/go-winres \

--- a/pkg/docker-engine/scripts/pkg-static-build.sh
+++ b/pkg/docker-engine/scripts/pkg-static-build.sh
@@ -111,9 +111,5 @@ for pkgname in *; do
       tar -czf "$pkgfile" -C "$workdir" "${pkgname}"
     )
   fi
-  (
-    set -x
-    cd "$pkgoutput"
-    sha256sum "${pkgfile##*/}" > "${pkgfile##*/}.sha256"
-  )
+  write-sha256sum "$pkgfile"
 done

--- a/pkg/docker-engine/scripts/pkg-static-build.sh
+++ b/pkg/docker-engine/scripts/pkg-static-build.sh
@@ -98,15 +98,22 @@ for pkgname in *; do
     cp "${pkgname}"/* ${SRCDIR}/LICENSE ${SRCDIR}/README.md "$workdir/${pkgname}/"
   )
   if [ "$(xx-info os)" = "windows" ]; then
+    pkgfile="${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.zip"
     (
       set -x
       cd "$workdir"
-      zip -r "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.zip" "${pkgname}"
+      zip -r "$pkgfile" "${pkgname}"
     )
   else
+    pkgfile="${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.tgz"
     (
       set -x
-      tar -czf "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.tgz" -C "$workdir" "${pkgname}"
+      tar -czf "$pkgfile" -C "$workdir" "${pkgname}"
     )
   fi
+  (
+    set -x
+    cd "$pkgoutput"
+    sha256sum "${pkgfile##*/}" > "${pkgfile##*/}.sha256"
+  )
 done

--- a/pkg/docker-engine/verify.Dockerfile
+++ b/pkg/docker-engine/verify.Dockerfile
@@ -121,7 +121,9 @@ RUN --mount=from=bin,target=/build <<EOT
   for package in $(find $dir -type f -name '*.tgz'); do
     (
       set -x
-      tar zxvf $package -C /usr/bin --strip-components=1
+      cd "${package%/*}"
+      sha256sum -c "${package##*/}.sha256"
+      tar zxvf "${package##*/}" -C /usr/bin --strip-components=1
     )
   done
   set -x

--- a/pkg/docker/Dockerfile
+++ b/pkg/docker/Dockerfile
@@ -161,6 +161,7 @@ RUN --mount=type=bind,source=scripts/pkg-static-build.sh,target=/usr/local/bin/p
     --mount=type=bind,source=scripts/check-gomod.sh,target=/usr/local/bin/check-gomod \
     --mount=type=bind,from=scripts,source=gen-ver.sh,target=/usr/local/bin/gen-ver \
     --mount=type=bind,from=scripts,source=fix-cc.sh,target=/usr/local/bin/fix-cc \
+    --mount=type=bind,from=scripts,source=write-sha256sum.sh,target=/usr/local/bin/write-sha256sum \
     --mount=type=bind,from=engine-src,source=/src,target=/go/src/github.com/docker/docker,rw \
     --mount=type=bind,from=cli-src,source=/src,target=/go/src/github.com/docker/cli,rw \
     --mount=type=bind,from=gocross,source=/usr/local/go,target=/usr/local/go,rw \

--- a/pkg/docker/scripts/pkg-static-build.sh
+++ b/pkg/docker/scripts/pkg-static-build.sh
@@ -242,8 +242,4 @@ else
     tar -czf "$pkgfile" -C "$workdir" docker
   )
 fi
-(
-  set -x
-  cd "$pkgoutput"
-  sha256sum "${pkgfile##*/}" > "${pkgfile##*/}.sha256"
-)
+write-sha256sum "$pkgfile"

--- a/pkg/docker/scripts/pkg-static-build.sh
+++ b/pkg/docker/scripts/pkg-static-build.sh
@@ -229,14 +229,21 @@ mkdir -p "$workdir/docker"
   fi
 )
 if [ "$(xx-info os)" = "windows" ]; then
+  pkgfile="${pkgoutput}/docker-${version_no_v}.zip"
   (
     set -x
     cd "$workdir"
-    zip -r "${pkgoutput}/docker-${version_no_v}.zip" docker
+    zip -r "$pkgfile" docker
   )
 else
+  pkgfile="${pkgoutput}/docker-${version_no_v}.tgz"
   (
     set -x
-    tar -czf "${pkgoutput}/docker-${version_no_v}.tgz" -C "$workdir" docker
+    tar -czf "$pkgfile" -C "$workdir" docker
   )
 fi
+(
+  set -x
+  cd "$pkgoutput"
+  sha256sum "${pkgfile##*/}" > "${pkgfile##*/}.sha256"
+)

--- a/pkg/docker/verify.Dockerfile
+++ b/pkg/docker/verify.Dockerfile
@@ -47,9 +47,11 @@ RUN --mount=from=bin,target=/build <<EOT
       found=1
       (
         set -x
-        unzip -l $package
+        cd "${package%/*}"
+        sha256sum -c "${package##*/}.sha256"
+        unzip -l "${package##*/}"
         workdir=$(mktemp -d -t docker-verify.XXXXXXXXXX)
-        unzip -q $package -d $workdir
+        unzip -q "${package##*/}" -d $workdir
         xx-verify --static $workdir/docker/docker.exe
         xx-verify --static $workdir/docker/dockerd.exe
         xx-verify --static $workdir/docker/containerd.exe
@@ -66,7 +68,9 @@ RUN --mount=from=bin,target=/build <<EOT
   for package in $(find $dir -type f -name '*.tgz'); do
     (
       set -x
-      tar zxvf $package -C /usr/bin --strip-components=1
+      cd "${package%/*}"
+      sha256sum -c "${package##*/}.sha256"
+      tar zxvf "${package##*/}" -C /usr/bin --strip-components=1
     )
   done
   set -x

--- a/pkg/model/Dockerfile
+++ b/pkg/model/Dockerfile
@@ -173,6 +173,7 @@ ARG TARGETPLATFORM
 RUN --mount=type=bind,source=scripts/pkg-static-build.sh,target=/usr/local/bin/pkg-static-build \
     --mount=type=bind,from=scripts,source=gen-ver.sh,target=/usr/local/bin/gen-ver \
     --mount=type=bind,from=scripts,source=fix-cc.sh,target=/usr/local/bin/fix-cc \
+    --mount=type=bind,from=scripts,source=write-sha256sum.sh,target=/usr/local/bin/write-sha256sum \
     --mount=type=bind,from=src,source=/src,target=/usr/local/src/model \
     --mount=type=bind,from=gocross,source=/usr/local/go,target=/usr/local/go,rw \
     OUTDIR=/out BUILDDIR=/build SRCDIR=/usr/local/src/model pkg-static-build

--- a/pkg/model/scripts/pkg-static-build.sh
+++ b/pkg/model/scripts/pkg-static-build.sh
@@ -74,15 +74,22 @@ for pkgname in *; do
     cp "${pkgname}"/* ${SRCDIR}/LICENSE "$workdir/${pkgname}/"
   )
   if [ "$(xx-info os)" = "windows" ]; then
+    pkgfile="${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.zip"
     (
       set -x
       cd "$workdir"
-      zip -r "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.zip" "${pkgname}"
+      zip -r "$pkgfile" "${pkgname}"
     )
   else
+    pkgfile="${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.tgz"
     (
       set -x
-      tar -czf "${pkgoutput}/${pkgname}_${GENVER_VERSION#v}.tgz" -C "$workdir" "${pkgname}"
+      tar -czf "$pkgfile" -C "$workdir" "${pkgname}"
     )
   fi
+  (
+    set -x
+    cd "$pkgoutput"
+    sha256sum "${pkgfile##*/}" > "${pkgfile##*/}.sha256"
+  )
 done

--- a/pkg/model/scripts/pkg-static-build.sh
+++ b/pkg/model/scripts/pkg-static-build.sh
@@ -87,9 +87,5 @@ for pkgname in *; do
       tar -czf "$pkgfile" -C "$workdir" "${pkgname}"
     )
   fi
-  (
-    set -x
-    cd "$pkgoutput"
-    sha256sum "${pkgfile##*/}" > "${pkgfile##*/}.sha256"
-  )
+  write-sha256sum "$pkgfile"
 done

--- a/pkg/model/verify.Dockerfile
+++ b/pkg/model/verify.Dockerfile
@@ -108,7 +108,9 @@ RUN --mount=from=bin,target=/build <<EOT
   for package in $(find $dir -type f -name '*.tgz'); do
     (
       set -x
-      tar zxvf $package -C /usr/bin --strip-components=1
+      cd "${package%/*}"
+      sha256sum -c "${package##*/}.sha256"
+      tar zxvf "${package##*/}" -C /usr/bin --strip-components=1
     )
   done
   set -x


### PR DESCRIPTION
~needs #493~
follow-up https://github.com/docker/packaging/pull/493#issuecomment-5296538846

Static package builds now emit a sibling .sha256 file for each generated .tgz and .zip archive. Static package verification checks the generated checksum before unpacking artifacts.