### PR TITLE
bake/containerd: Align Go version

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -574,8 +574,8 @@ target "_pkg-containerd" {
   args = {
     PKG_NAME = PKG_NAME != null && PKG_NAME != "" ? PKG_NAME : "containerd"
     PKG_REPO = PKG_REPO != null && PKG_REPO != "" ? PKG_REPO : "https://github.com/containerd/containerd.git"
-    PKG_REF = PKG_REF != null && PKG_REF != "" ? PKG_REF : "release/2.2"
-    GO_VERSION = GO_VERSION != null && GO_VERSION != "" ? GO_VERSION : "1.25.12" # https://github.com/containerd/containerd/blob/release/2.2/.github/workflows/release/Dockerfile
+    PKG_REF = PKG_REF != null && PKG_REF != "" ? PKG_REF : "release/2.3"
+    GO_VERSION = GO_VERSION != null && GO_VERSION != "" ? GO_VERSION : "1.26.5" # https://github.com/containerd/containerd/blob/release/2.3/.github/workflows/release/Dockerfile
     GO_IMAGE_VARIANT = GO_IMAGE_VARIANT != null && GO_IMAGE_VARIANT != "" ? GO_IMAGE_VARIANT : "bookworm"
     PKG_DEB_EPOCH = PKG_DEB_EPOCH != null && PKG_DEB_EPOCH != "" ? PKG_DEB_EPOCH : ""
     RUNC_REF = RUNC_REF != null && RUNC_REF != "" ? RUNC_REF : null


### PR DESCRIPTION
- replace / close: https://github.com/docker/packaging/pull/466

We currently ship containerd 2.3 releases as stable so let's track Go updates for its release branch.