### PR TITLE
docker-engine/rpm: Package all SELinux policies

### DIFF
--- a/pkg/docker-engine/rpm/docker-ce.spec
+++ b/pkg/docker-engine/rpm/docker-ce.spec
@@ -91,8 +91,9 @@ install -D -p -m 0644 engine/contrib/init/systemd/docker.socket ${RPM_BUILD_ROOT
 # install manpages
 make -C ${RPM_BUILD_DIR}/src/engine/man DESTDIR=${RPM_BUILD_ROOT} mandir=%{_mandir} install
 
-# install SELinux policy to deny AF_ALG sockets in container domains
-install -D -m 644 engine/contrib/selinux/docker-af-alg-deny.cil %{buildroot}%{_datadir}/docker-ce/selinux/docker-af-alg-deny.cil
+# install SELinux policies
+install -d -m 755 %{buildroot}%{_datadir}/docker-ce/selinux
+install -m 644 engine/contrib/selinux/*.cil %{buildroot}%{_datadir}/docker-ce/selinux/
 
 # create the config directory
 mkdir -p ${RPM_BUILD_ROOT}/etc/docker
@@ -104,7 +105,7 @@ mkdir -p ${RPM_BUILD_ROOT}/etc/docker
 %{_unitdir}/docker.service
 %{_unitdir}/docker.socket
 %{_mandir}/man*/*
-%{_datadir}/docker-ce/selinux/docker-af-alg-deny.cil
+%{_datadir}/docker-ce/selinux/*.cil
 %dir /etc/docker
 
 %post


### PR DESCRIPTION
- same as: https://github.com/docker/docker-ce-packaging/pull/1347

In case there are more SELinux policies in future versions, copy them all.