### PR TITLE
pkg/containerd: Fix build with runc 1.5

### DIFF
--- a/pkg/containerd/deb/rules
+++ b/pkg/containerd/deb/rules
@@ -34,8 +34,10 @@ binaries: ## Create containerd binaries
 	rm -f bin/containerd-stress
 
 bin/runc:
+	# Use runc's pathrs-lite backend until supported distributions package libpathrs.
 	@set -x; GO111MODULE=auto make -C /go/src/github.com/opencontainers/runc  --no-print-directory \
 		BINDIR="$$(pwd)/bin" \
+		RUNC_BUILDTAGS="-libpathrs" \
 		runc install
 
 man: ## Create containerd man pages

--- a/pkg/containerd/rpm/containerd.spec
+++ b/pkg/containerd/rpm/containerd.spec
@@ -104,7 +104,8 @@ rm -f bin/containerd-stress
 bin/containerd --version
 bin/ctr --version
 
-GO111MODULE=auto make -C /go/src/github.com/opencontainers/runc BINDIR=%{_builddir}/bin runc install
+# Use runc's pathrs-lite backend until supported distributions package libpathrs.
+GO111MODULE=auto make -C /go/src/github.com/opencontainers/runc BINDIR=%{_builddir}/bin RUNC_BUILDTAGS="-libpathrs" runc install
 
 
 %install

--- a/pkg/containerd/scripts/pkg-static-build.sh
+++ b/pkg/containerd/scripts/pkg-static-build.sh
@@ -103,7 +103,8 @@ else
   (
     set -x
     pushd ${RUNC_SRCDIR}
-      make static
+      # Use runc's pathrs-lite backend until supported distributions package libpathrs.
+      make RUNC_BUILDTAGS="-libpathrs" static
       mv runc "${BUILDDIR}/${PKG_NAME}"
     popd
     xx-verify --static  "${BUILDDIR}/${PKG_NAME}/runc"


### PR DESCRIPTION
runc 1.5 enables libpathrs by default, but the supported package builders do not provide that native library. This caused Debian, RPM, and static builds to fail during pkg-config lookup.

Pass RUNC_BUILDTAGS=-libpathrs for each runc build. runc continues to use its pathrs-lite safe-resolution backend without the unavailable dependency.