### PR TITLE
ci: add release workflow run names

### DIFF
--- a/.github/workflows/release-agent.yml
+++ b/.github/workflows/release-agent.yml
@@ -1,4 +1,5 @@
 name: release-agent
+run-name: ${{ github.workflow }} ${{ inputs.ref }} (${{ inputs.release }})
 
 permissions:
   contents: read

--- a/.github/workflows/release-buildx.yml
+++ b/.github/workflows/release-buildx.yml
@@ -1,4 +1,5 @@
 name: release-buildx
+run-name: ${{ github.workflow }} ${{ inputs.ref }} (${{ inputs.release }})
 
 permissions:
   contents: read

--- a/.github/workflows/release-compose.yml
+++ b/.github/workflows/release-compose.yml
@@ -1,4 +1,5 @@
 name: release-compose
+run-name: ${{ github.workflow }} ${{ inputs.ref }} (${{ inputs.release }})
 
 permissions:
   contents: read

--- a/.github/workflows/release-containerd.yml
+++ b/.github/workflows/release-containerd.yml
@@ -1,4 +1,5 @@
 name: release-containerd
+run-name: ${{ github.workflow }} ${{ inputs.ref }} (${{ inputs.release }})
 
 permissions:
   contents: read

--- a/.github/workflows/release-credential-helpers.yml
+++ b/.github/workflows/release-credential-helpers.yml
@@ -1,4 +1,5 @@
 name: release-credential-helpers
+run-name: ${{ github.workflow }} ${{ inputs.ref }} (${{ inputs.release }})
 
 permissions:
   contents: read

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -1,4 +1,5 @@
 name: release-docker
+run-name: ${{ github.workflow }} ${{ inputs.version }} (${{ inputs.release }})
 
 permissions:
   contents: read

--- a/.github/workflows/release-model.yml
+++ b/.github/workflows/release-model.yml
@@ -1,4 +1,5 @@
 name: release-model
+run-name: ${{ github.workflow }} ${{ inputs.ref }} (${{ inputs.release }})
 
 permissions:
   contents: read


### PR DESCRIPTION
This adds explicit run names to the release workflows so manually dispatched releases are easier to identify in the GitHub Actions UI. Each run now includes the workflow name, the release ref or Docker version, and the selected release mode.