### PR TITLE
packaging: Drop Debian 11 Bullseye support

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -17,7 +17,6 @@ variable "DISTROS" {
   default = [
     "static",
 
-    "debian11",
     "debian12",
     "debian13",
     "ubuntu2204",
@@ -123,11 +122,11 @@ variable "DISTRO_RELEASE" {
   default = null
 }
 variable "DISTRO_ID" {
-  description = "Distro ID, e.g. 11 for debian11, 12 for debian12, etc."
+  description = "Distro ID, e.g. 12 for debian12, 13 for debian13, etc."
   default = null
 }
 variable "DISTRO_SUITE" {
-  description = "Distro suite name, e.g. bullseye for debian11, bookworm for debian12, etc."
+  description = "Distro suite name, e.g. bookworm for debian12, trixie for debian13, etc."
   default = null
 }
 variable "DISTRO_IMAGE" {
@@ -245,18 +244,6 @@ target "_distro-static" {
     DISTRO_ID = ""
     DISTRO_SUITE = ""
     DISTRO_IMAGE = DISTRO_IMAGE != null && DISTRO_IMAGE != "" ? DISTRO_IMAGE : "debian:trixie"
-    TEST_ONLY = "0"
-  }
-}
-
-target "_distro-debian11" {
-  args = {
-    DISTRO_NAME = "debian11"
-    DISTRO_TYPE = "deb"
-    DISTRO_RELEASE = "debian"
-    DISTRO_ID = "11"
-    DISTRO_SUITE = "bullseye"
-    DISTRO_IMAGE = DISTRO_IMAGE != null && DISTRO_IMAGE != "" ? DISTRO_IMAGE : "debian:bullseye"
     TEST_ONLY = "0"
   }
 }
@@ -525,7 +512,6 @@ function "distroPlatforms" {
       lookup({
         static = pkgPlatforms(pkg)
 
-        debian11 = ["linux/386", "linux/amd64", "linux/arm64", "linux/arm/v7", "linux/mips64le", "linux/ppc64le", "linux/s390x"]
         debian12 = ["linux/386", "linux/amd64", "linux/arm64", "linux/arm/v7", "linux/mips64le", "linux/ppc64le", "linux/s390x"]
         debian13 = ["linux/386", "linux/amd64", "linux/arm64", "linux/arm/v7", "linux/mips64le", "linux/ppc64le", "linux/riscv64", "linux/s390x"]
         ubuntu2204 = ["linux/amd64", "linux/arm64", "linux/arm/v7", "linux/ppc64le", "linux/s390x"]

--- a/hack/scripts/gen-deb-changelog.sh
+++ b/hack/scripts/gen-deb-changelog.sh
@@ -57,10 +57,10 @@ pkgDate="$(date --rfc-2822)"
 #   packaging-only changes (without a corresponding release of the software
 #   that's packaged).
 # - distro (e.g., "ubuntu")
-# - VERSION_ID (e.g. "22.04" or "11") this must be "sortable" to make sure that
+# - VERSION_ID (e.g. "22.04" or "12") this must be "sortable" to make sure that
 #   packages are upgraded when upgrading to a newer distro version ("codename"
 #   cannot be used for this, as they're not sorted)
-# - SUITE ("codename"), e.g. "jammy" or "bullseye". This is mostly for convenience,
+# - SUITE ("codename"), e.g. "jammy" or "bookworm". This is mostly for convenience,
 #   because some places refer to distro versions by codename, others by version.
 #   we prefix the codename with a tilde (~), which effectively excludes it from
 #   version comparison.
@@ -72,7 +72,7 @@ pkgDate="$(date --rfc-2822)"
 #
 # Examples:
 #
-# docker-ce_23.0.0~beta.0-1~debian.11~bullseye_amd64.deb
+# docker-ce_23.0.0~beta.0-1~debian.12~bookworm_amd64.deb
 # docker-ce_23.0.0~beta.0-1~ubuntu.22.04~jammy_amd64.deb
 
 if [[ -f "debian/changelog" ]] && [[ "${version}" != "v${pkgVersion}" ]]; then


### PR DESCRIPTION
Debian 11 is EOL: https://www.debian.org/releases/bullseye/