### PR TITLE
pkg/docker: Fix static builds with runc 1.5

### DIFF
--- a/pkg/docker/scripts/pkg-static-build.sh
+++ b/pkg/docker/scripts/pkg-static-build.sh
@@ -174,7 +174,8 @@ if [ "$(xx-info os)" = "linux" ]; then
     set -x
     fetch_git_ref "https://github.com/opencontainers/runc.git" "$runc_version" "$runc_srcdir"
     pushd "$runc_srcdir"
-      CGO_ENABLED=1 GO111MODULE=on make static
+      # Use runc's pathrs-lite backend until supported distributions package libpathrs.
+      CGO_ENABLED=1 GO111MODULE=on make RUNC_BUILDTAGS="-libpathrs" static
       mv runc "$runtime_builddir/"
     popd
     xx-verify --static "${runtime_builddir}/runc"


### PR DESCRIPTION
- follow up to: https://github.com/docker/packaging/pull/508

runc 1.5 enables libpathrs by default, but the Docker static builder had no native libpathrs dependency, so runc failed during pkg-config lookup.

Select runc's pathrs-lite backend with RUNC_BUILDTAGS=-libpathrs, matching the containerd packaging while preserving the other default build tags.